### PR TITLE
Add custom wallet support for staking rewards

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -401,7 +401,7 @@ body::-webkit-scrollbar {
   box-shadow: none !important;
 }
 
-.btnPadd{
+.btnPadd {
   padding-left: 8px !important;
   padding-right: 8px !important;
 }
@@ -1088,6 +1088,26 @@ a,
 }
 
 
+.errorMsg {
+  background-color: #431d1d !important;
+
+  p,
+  svg {
+    color: #f99c9c !important;
+  }
+
+  a,
+  .a {
+    color: #f99c9c !important;
+
+    p,
+    svg {
+      color: #f99c9c !important;
+    }
+  }
+}
+
+
 .appIconHub {
   border-radius: 25px;
   background: rgba(0, 0, 0, 0.506) !important;
@@ -1118,4 +1138,23 @@ a,
 
 .paddBott60 {
   padding-bottom: 60px;
+}
+
+
+.MuiBackdrop-root {
+  backdrop-filter: blur(3px) !important;
+}
+
+.pSec {
+  color: RGB(255 255 255 / 65%);
+}
+
+.addressInput {
+  input {
+    color: rgba(255, 255, 255, 0.8) !important;
+  }
+
+  .Mui-disabled {
+    -webkit-text-fill-color: #ffffff;
+  }
 }

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -1,4 +1,4 @@
-$sk-border-radius: 15px;
+$sk-border-radius: 25px;
 
 $sk-paper-color: rgb(136 135 135 / 15%);
 $sk-gray-background-color: rgba(161, 161, 161, 0.2);

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -36,13 +36,23 @@ export default function Message(props: {
   icon: ReactElement
   className?: string | undefined
   showOnLoad?: boolean | undefined
-  type?: 'warning' | 'info'
+  type?: 'warning' | 'info' | 'error'
+  closable?: boolean
 }) {
   const type = props.type ?? 'info'
   const [show, setShow] = useState<boolean>(true)
+  const closable = props.closable ?? true
   return (
     <Collapse in={show}>
-      <SkPaper gray className={cls(props.className, 'border', ['warningMsg', type === 'warning'])}>
+      <SkPaper
+        gray
+        className={cls(
+          props.className,
+          'border',
+          ['warningMsg', type === 'warning'],
+          ['errorMsg', type === 'error']
+        )}
+      >
         <div
           className={cls(cmn.flex, cmn.fullWidth, cmn.flexcv, cmn.mtopd5, cmn.mbotdt5, cmn.mleft10)}
         >
@@ -65,19 +75,21 @@ export default function Message(props: {
           ) : null}
 
           <div className={cmn.flexg}></div>
-          <div className={cls(cmn.mri20)}>
-            <IconButton
-              onClick={() => {
-                setShow(false)
-              }}
-              className={cls(cmn.paperGrey, cmn.mleft10)}
-            >
-              <CloseRoundedIcon
-                className={cls([cmn.pSec, type !== 'warning'])}
-                style={{ height: '16px', width: '16px' }}
-              />
-            </IconButton>
-          </div>
+          {closable ? (
+            <div className={cls(cmn.mri20)}>
+              <IconButton
+                onClick={() => {
+                  setShow(false)
+                }}
+                className={cls(cmn.paperGrey, cmn.mleft10)}
+              >
+                <CloseRoundedIcon
+                  className={cls([cmn.pSec, type !== 'warning'])}
+                  style={{ height: '16px', width: '16px' }}
+                />
+              </IconButton>
+            </div>
+          ) : null}
         </div>
       </SkPaper>
     </Collapse>

--- a/src/components/Tile.tsx
+++ b/src/components/Tile.tsx
@@ -84,7 +84,7 @@ export default function Tile(props: {
         [cmn.p2, size === 'md'],
         cmn.p700,
         [cmn.pPrim, !props.color && !props.disabled],
-        [cmn.pSec, props.disabled],
+        ['pSec', props.disabled],
         ['blackP', props.color],
         ['pointer', props.copy]
       )}
@@ -109,7 +109,7 @@ export default function Tile(props: {
                 cmn.flex,
                 cmn.flexcv,
                 cmn.mbott5,
-                [cmn.pSec, !props.color],
+                ['pSec', !props.color],
                 ['blackP', props.color]
               )}
             >

--- a/src/components/delegation/Delegations.tsx
+++ b/src/components/delegation/Delegations.tsx
@@ -48,7 +48,10 @@ export default function Delegations(props: {
   unstake: (delegationInfo: IDelegationInfo) => Promise<void>
   cancelRequest: (delegationInfo: IDelegationInfo) => Promise<void>
   isXs: boolean
+  address: interfaces.AddressType | undefined
   customAddress: interfaces.AddressType | undefined
+  customRewardAddress: interfaces.AddressType | undefined
+  setCustomRewardAddress: (customRewardAddress: interfaces.AddressType | undefined) => void
 }) {
   const loaded = props.si[DelegationType.REGULAR] !== null
   const noDelegations =
@@ -91,7 +94,10 @@ export default function Delegations(props: {
                 unstake={props.unstake}
                 cancelRequest={props.cancelRequest}
                 isXs={props.isXs}
+                address={props.address}
                 customAddress={props.customAddress}
+                customRewardAddress={props.customRewardAddress}
+                setCustomRewardAddress={props.setCustomRewardAddress}
               />
             )
           )}
@@ -107,7 +113,10 @@ export default function Delegations(props: {
                 unstake={props.unstake}
                 cancelRequest={props.cancelRequest}
                 isXs={props.isXs}
+                address={props.address}
                 customAddress={props.customAddress}
+                customRewardAddress={props.customRewardAddress}
+                setCustomRewardAddress={props.setCustomRewardAddress}
               />
             )
           )}
@@ -123,7 +132,10 @@ export default function Delegations(props: {
                 unstake={props.unstake}
                 cancelRequest={props.cancelRequest}
                 isXs={props.isXs}
+                address={props.address}
                 customAddress={props.customAddress}
+                customRewardAddress={props.customRewardAddress}
+                setCustomRewardAddress={props.setCustomRewardAddress}
               />
             )
           )}

--- a/src/components/delegation/DelegationsToValidator.tsx
+++ b/src/components/delegation/DelegationsToValidator.tsx
@@ -45,7 +45,10 @@ export default function DelegationsToValidator(props: {
   unstake: (delegationInfo: IDelegationInfo) => Promise<void>
   cancelRequest: (delegationInfo: IDelegationInfo) => Promise<void>
   isXs: boolean
+  address: interfaces.AddressType | undefined
   customAddress: interfaces.AddressType | undefined
+  customRewardAddress: interfaces.AddressType | undefined
+  setCustomRewardAddress: (customRewardAddress: interfaces.AddressType | undefined) => void
 }) {
   const [open, setOpen] = useState(true)
   return (
@@ -59,7 +62,10 @@ export default function DelegationsToValidator(props: {
         loading={props.loading}
         delegationType={props.delegationType}
         isXs={props.isXs}
+        address={props.address}
         customAddress={props.customAddress}
+        customRewardAddress={props.customRewardAddress}
+        setCustomRewardAddress={props.setCustomRewardAddress}
       />
 
       <Collapse in={open}>

--- a/src/components/delegation/RetrieveRewardModal.tsx
+++ b/src/components/delegation/RetrieveRewardModal.tsx
@@ -1,0 +1,209 @@
+/**
+ * @license
+ * SKALE portal
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+/**
+ * @file RetrieveRewardModal.tsx
+ * @copyright SKALE Labs 2024-Present
+ */
+
+import { useState, useEffect, ChangeEvent } from 'react'
+import { isAddress } from 'ethers'
+
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Modal from '@mui/material/Modal'
+import { SkPaper, cls, cmn, interfaces, styles } from '@skalenetwork/metaport'
+import Tile from '../Tile'
+import { Collapse, Container, TextField } from '@mui/material'
+
+import PersonRoundedIcon from '@mui/icons-material/PersonRounded'
+import WarningRoundedIcon from '@mui/icons-material/WarningRounded'
+import ReportProblemRoundedIcon from '@mui/icons-material/ReportProblemRounded'
+
+import Jazzicon from 'react-jazzicon/dist/Jazzicon'
+import { jsNumberForAddress } from 'react-jazzicon'
+import Message from '../Message'
+import { ZERO_ADDRESS } from '../../core/constants'
+import SkBtn from '../SkBtn'
+
+const style = {
+  position: 'absolute' as 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  minWidth: '100vw'
+}
+
+export default function RetrieveRewardModal(props: {
+  address: interfaces.AddressType | undefined
+  customRewardAddress: interfaces.AddressType | undefined
+  setCustomRewardAddress: (customRewardAddress: interfaces.AddressType | undefined) => void
+  retrieveRewards: () => void
+  loading: boolean
+  disabled: boolean
+}) {
+  const [edit, setEdit] = useState(false)
+  const [inputAddress, setInputAddress] = useState<string | undefined>(props.customRewardAddress)
+  const [errorMsg, setErrorMsg] = useState<string | undefined>(undefined)
+  const [open, setOpen] = useState(false)
+  const handleOpen = () => setOpen(true)
+  const handleClose = () => setOpen(false)
+
+  useEffect(() => {
+    setInputAddress(props.address)
+  }, [props.address])
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setInputAddress(event.target.value)
+  }
+
+  const saveAddress = () => {
+    if (isAddress(inputAddress)) {
+      props.setCustomRewardAddress(inputAddress as interfaces.AddressType)
+      setEdit(false)
+      setErrorMsg(undefined)
+    } else {
+      setErrorMsg('Address is not valid')
+    }
+  }
+
+  return (
+    <div>
+      <Button
+        variant="contained"
+        className={cls('btnSm')}
+        onClick={handleOpen}
+        disabled={props.disabled}
+      >
+        Retrieve
+      </Button>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+      >
+        <Box sx={style}>
+          <Container maxWidth="md">
+            <SkPaper className={cls(cmn.nop)}>
+              <SkPaper gray>
+                <p className={cls(cmn.p, cmn.p1, cmn.p700, cmn.pCent, cmn.mtop10, cmn.mbott10)}>
+                  Confirm reward retrieval
+                </p>
+                <Message
+                  text="Double-check the address. Withdrawing to a wallet you don't control will lead to permanent loss of funds."
+                  type="warning"
+                  icon={<WarningRoundedIcon />}
+                  className={cls(cmn.mbott10)}
+                />
+                <Collapse in={!!errorMsg}>
+                  <Message
+                    text={errorMsg ?? ''}
+                    type="error"
+                    icon={<ReportProblemRoundedIcon />}
+                    className={cls(cmn.mbott10)}
+                    closable={false}
+                  />
+                </Collapse>
+                <Tile
+                  text="Receiver address"
+                  className={cls(styles.inputAmount)}
+                  children={
+                    <div className={cls(cmn.flex, cmn.flexcv, cmn.mtop5)}>
+                      <div className={cls(cmn.flexg)}>
+                        <div
+                          className={cls(
+                            cmn.flex,
+                            cmn.flexg,
+                            cmn.flexcv,
+                            'amountInput',
+                            'addressInput'
+                          )}
+                        >
+                          <Jazzicon
+                            diameter={25}
+                            seed={jsNumberForAddress(
+                              (edit ? inputAddress : props.customRewardAddress) || ''
+                            )}
+                          />
+                          <div className={cls(cmn.flexg, cmn.mleft10)}>
+                            <TextField
+                              inputRef={(input) => input?.focus()}
+                              variant="standard"
+                              placeholder={ZERO_ADDRESS}
+                              value={edit ? inputAddress : props.customRewardAddress}
+                              onChange={handleChange}
+                              disabled={!edit}
+                              style={{ width: '100%' }}
+                            />
+                          </div>
+                        </div>
+                      </div>
+                      <div>
+                        {edit ? (
+                          <div>
+                            <Button
+                              variant="text"
+                              className={cls('btnSm', 'outlined')}
+                              onClick={saveAddress}
+                            >
+                              Save
+                            </Button>
+                            <Button
+                              variant="text"
+                              className={cls('btnSm', 'outlined', cmn.mleft10)}
+                              onClick={() => {
+                                setInputAddress(props.address)
+                                props.setCustomRewardAddress(props.address)
+                                setEdit(false)
+                                setErrorMsg(undefined)
+                              }}
+                            >
+                              Reset
+                            </Button>
+                          </div>
+                        ) : (
+                          <Button
+                            variant="text"
+                            className={cls('btnSm', 'outlined')}
+                            onClick={() => setEdit(!edit)}
+                            disabled={props.disabled}
+                          >
+                            Change
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                  }
+                  icon={<PersonRoundedIcon />}
+                  grow
+                />
+                <SkBtn
+                  text={props.loading ? 'Retrieving' : 'Retrieve'}
+                  disabled={props.disabled || edit}
+                  onClick={props.retrieveRewards}
+                  className={cls('btn', cmn.mleft10, cmn.mbott10, cmn.mtop20)}
+                  variant="contained"
+                />
+              </SkPaper>
+            </SkPaper>
+          </Container>
+        </Box>
+      </Modal>
+    </div>
+  )
+}

--- a/src/components/delegation/Reward.tsx
+++ b/src/components/delegation/Reward.tsx
@@ -23,7 +23,6 @@
 import { cmn, cls, styles, type interfaces } from '@skalenetwork/metaport'
 
 import { Grid } from '@mui/material'
-import Button from '@mui/material/Button'
 import LoadingButton from '@mui/lab/LoadingButton'
 
 import AddCircleRoundedIcon from '@mui/icons-material/AddCircleRounded'
@@ -40,6 +39,7 @@ import {
 } from '../../core/interfaces'
 import { getValidatorById } from '../../core/delegation'
 import { formatBalance } from '../../core/helper'
+import RetrieveRewardModal from './RetrieveRewardModal'
 
 export default function Reward(props: {
   validators: IValidator[]
@@ -50,7 +50,10 @@ export default function Reward(props: {
   loading: IRewardInfo | IDelegationInfo | false
   delegationType: DelegationType
   isXs: boolean
+  address: interfaces.AddressType | undefined
   customAddress: interfaces.AddressType | undefined
+  customRewardAddress: interfaces.AddressType | undefined
+  setCustomRewardAddress: (customRewardAddress: interfaces.AddressType | undefined) => void
 }) {
   const validator = getValidatorById(props.validators, props.delegationsToValidator.validatorId)
   const rewardsAmount = formatBalance(props.delegationsToValidator.rewards, 'SKL')
@@ -78,75 +81,81 @@ export default function Reward(props: {
     </div>
   )
 
+  function retrieveRewards() {
+    if (!validator) return
+    props.retrieveRewards({
+      validatorId: validator.id,
+      delegationType: props.delegationType
+    })
+  }
+
+  const retrieveDisabled =
+    props.delegationsToValidator.rewards === 0n ||
+    props.loading !== false ||
+    props.customAddress !== undefined
+
   return (
-    <div className={cls(cmn.mbott10, 'titleSection')}>
-      <Grid container spacing={0} alignItems="center">
-        <Grid item md={4} xs={12}>
-          <div className={cls(cmn.flex, cmn.flexcv)}>
-            <ValidatorLogo validatorId={validator.id} size="lg" />
-            <div className={cls(cmn.mleft10, [cmn.flexg, props.isXs])}>
-              <h4 className={cls(cmn.p, cmn.p700, 'pOneLine')}>{validator.name}</h4>
-              <p className={cls(cmn.p, cmn.p4, cmn.pSec)}>Validator ID: {Number(validator.id)}</p>
-            </div>
-            {props.isXs ? minimizeBtn : null}
-          </div>
-        </Grid>
-        <Grid item md={8} xs={12} className={cls([cmn.mtop20, props.isXs])}>
-          <div className={cls(cmn.flex, cmn.flexcv)}>
-            <div className={cls([cmn.flexg, !props.isXs])}></div>
-            {!props.isXs && !props.open ? (
-              <div className={cls([cmn.pri, !props.isXs], cmn.flex)}>
-                <div>
-                  <p className={cls(cmn.p, cmn.p4, cmn.pSec)}>Total staked</p>
-                  <h3 className={cls(cmn.p, cmn.p700)}>{totalStakedAmount}</h3>
-                </div>
-                <div className={cls('borderVert', cmn.mleft20)}></div>
+    <div>
+      <div className={cls(cmn.mbott10, 'titleSection')}>
+        <Grid container spacing={0} alignItems="center">
+          <Grid item md={4} xs={12}>
+            <div className={cls(cmn.flex, cmn.flexcv)}>
+              <ValidatorLogo validatorId={validator.id} size="lg" />
+              <div className={cls(cmn.mleft10, [cmn.flexg, props.isXs])}>
+                <h4 className={cls(cmn.p, cmn.p700, 'pOneLine')}>{validator.name}</h4>
+                <p className={cls(cmn.p, cmn.p4, cmn.pSec)}>Validator ID: {Number(validator.id)}</p>
               </div>
-            ) : null}
-            <div
-              className={cls(
-                [cmn.flexg, props.isXs],
-                cmn.mri20,
-                [cmn.pri, !props.isXs],
-                [cmn.mleft20, !props.isXs]
-              )}
-            >
-              <p className={cls(cmn.p, cmn.p4, cmn.pSec)}>Rewards available</p>
-              <h3 className={cls(cmn.p, cmn.p700)}>{rewardsAmount}</h3>
+              {props.isXs ? minimizeBtn : null}
             </div>
-            {loading ? (
-              <LoadingButton
-                loading
-                loadingPosition="start"
-                size="small"
-                variant="contained"
-                className={cls('btnSm btnSmLoading')}
+          </Grid>
+          <Grid item md={8} xs={12} className={cls([cmn.mtop20, props.isXs])}>
+            <div className={cls(cmn.flex, cmn.flexcv)}>
+              <div className={cls([cmn.flexg, !props.isXs])}></div>
+              {!props.isXs && !props.open ? (
+                <div className={cls([cmn.pri, !props.isXs], cmn.flex)}>
+                  <div>
+                    <p className={cls(cmn.p, cmn.p4, cmn.pSec)}>Total staked</p>
+                    <h3 className={cls(cmn.p, cmn.p700)}>{totalStakedAmount}</h3>
+                  </div>
+                  <div className={cls('borderVert', cmn.mleft20)}></div>
+                </div>
+              ) : null}
+              <div
+                className={cls(
+                  [cmn.flexg, props.isXs],
+                  cmn.mri20,
+                  [cmn.pri, !props.isXs],
+                  [cmn.mleft20, !props.isXs]
+                )}
               >
-                Retrieving
-              </LoadingButton>
-            ) : (
-              <Button
-                variant="contained"
-                className={cls('btnSm')}
-                disabled={
-                  props.delegationsToValidator.rewards === 0n ||
-                  props.loading !== false ||
-                  props.customAddress !== undefined
-                }
-                onClick={() => {
-                  props.retrieveRewards({
-                    validatorId: validator.id,
-                    delegationType: props.delegationType
-                  })
-                }}
-              >
-                Retrieve
-              </Button>
-            )}
-            {!props.isXs ? minimizeBtn : null}
-          </div>
+                <p className={cls(cmn.p, cmn.p4, cmn.pSec)}>Rewards available</p>
+                <h3 className={cls(cmn.p, cmn.p700)}>{rewardsAmount}</h3>
+              </div>
+              {loading ? (
+                <LoadingButton
+                  loading
+                  loadingPosition="start"
+                  size="small"
+                  variant="contained"
+                  className={cls('btnSm btnSmLoading')}
+                >
+                  Retrieving
+                </LoadingButton>
+              ) : (
+                <RetrieveRewardModal
+                  address={props.address}
+                  disabled={retrieveDisabled}
+                  customRewardAddress={props.customRewardAddress}
+                  setCustomRewardAddress={props.setCustomRewardAddress}
+                  retrieveRewards={retrieveRewards}
+                  loading={loading}
+                />
+              )}
+              {!props.isXs ? minimizeBtn : null}
+            </div>
+          </Grid>
         </Grid>
-      </Grid>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
This PR adds an ability to retrieve staking rewards to the custom address. 
By default, connect wallet address is pre-filled, user can modify the address. 

Modified address saved for the currently open tab.

Rewards retrieval to custom address tested to testnet network.

No unit tests added, no performance changes.