### PR TITLE
Add ETH to Tokens tab, fix connect to chain

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -429,7 +429,7 @@ body::-webkit-scrollbar {
 }
 
 .btnPadd {
-  width: inherit !important;
+  width: inherit;
   padding-left: 8px !important;
   padding-right: 8px !important;
 }

--- a/src/components/SchainDetails.tsx
+++ b/src/components/SchainDetails.tsx
@@ -94,7 +94,8 @@ export default function SchainDetails(props: {
       name: 'sFUEL',
       symbol: 'sFUEL',
       decimals: 18
-    }
+    },
+    blockExplorerUrls: [explorerUrl]
   }
 
   async function addNetwork() {
@@ -225,10 +226,13 @@ export default function SchainDetails(props: {
                 <SkBtn
                   startIcon={added ? <CheckCircleRoundedIcon /> : <AddCircleRoundedIcon />}
                   size="md"
-                  className={cls(styles.btnAction, cmn.mri10, 'btnPadd', [
-                    'btnPaddLoading',
-                    loading
-                  ])}
+                  className={cls(
+                    styles.btnAction,
+                    cmn.mri10,
+                    'btnPadd',
+                    ['btnPaddLoading', loading],
+                    [cmn.fullWidth, props.isXs]
+                  )}
                   onClick={addNetwork}
                   disabled={loading}
                   text={connectBtnText()}

--- a/src/pages/Chains.tsx
+++ b/src/pages/Chains.tsx
@@ -135,6 +135,7 @@ export default function Chains(props: {
             icon={<CategoryRoundedIcon color="primary" />}
           />
         )}
+        <div className={cls(cmn.mbott20, cmn.mtop20)}></div>
       </Stack>
     </Container>
   )


### PR DESCRIPTION
This PR:

- Adds ETH clones to Tokens tab on Chain details page
- Fixes error with "Connect to Chain" by adding block explorer URL