### PR TITLE
tokens-on-bridge-4.1

### DIFF
--- a/config/testnet/index.ts
+++ b/config/testnet/index.ts
@@ -20,7 +20,7 @@ export const METAPORT_CONFIG: types.mp.Config = {
     skl: {
       decimals: 18,
       name: 'SKALE',
-      symbol: 'SKL'
+      symbol: 'SKL',
     },
     usdc: {
       decimals: 6,
@@ -49,7 +49,7 @@ export const METAPORT_CONFIG: types.mp.Config = {
     usdp: {
       name: 'Pax Dollar',
       symbol: 'USDP',
-      iconUrl: 'https://ruby.exchange/images/tokens/usdp-square.png'
+      iconUrl: 'https://s2.coinmarketcap.com/static/img/coins/64x64/3330.png'
     },
     hmt: {
       name: 'Human Token',
@@ -64,12 +64,13 @@ export const METAPORT_CONFIG: types.mp.Config = {
     },
     trc: {
       name: "TheRealCoin",
-      symbol: "TRC"
+      symbol: "TRC",
+      iconUrl: 'https://cdn.coinranking.com/hiytXsMNZ/6717a9ad9119fa1b2a5a077f4aa45d55.png'
     },
     skivvy: {
       name: 'Skivvy',
       symbol: '$SKIVVY',
-      decimals: '8',
+      decimals: 8,
       iconUrl: 'https://s2.coinmarketcap.com/static/img/coins/64x64/3441.png'
     },
     unp: {

--- a/packages/metaport/src/components/TokenBalance.tsx
+++ b/packages/metaport/src/components/TokenBalance.tsx
@@ -42,7 +42,7 @@ export default function TokenBalance(props: {
     <div className={cls(cmn.flex, cmn.flexcv)}>
       <p
         className={cls(
-          cmn.p,
+          cmn.pLightGrey,
           [cmn.p4, size === 'xs'],
           [cmn.p3, size === 'sm'],
           [cmn.pSec, !props.primary],
@@ -51,6 +51,7 @@ export default function TokenBalance(props: {
           cmn.flexcv,
           cmn.mri5
         )}
+        style={{ color: 'lightgrey' }}
       >
         {balance} {props.symbol}
       </p>

--- a/packages/metaport/src/components/TokenList.tsx
+++ b/packages/metaport/src/components/TokenList.tsx
@@ -34,23 +34,50 @@ import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded'
 
 import { getAvailableTokensTotal, getDefaultToken } from '../core/tokens/helper'
 
+
 import { cls, cmn, styles } from '../core/css'
 
 import TokenListSection from './TokenListSection'
 import TokenIcon from './TokenIcon'
 
+
 import { useCollapseStore } from '../store/Store'
 import { useMetaportStore } from '../store/MetaportStore'
 import { BALANCE_UPDATE_INTERVAL_MS } from '../core/constants'
+import { Box, Button, Modal } from '@mui/material'
+
+
+const style = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: '#202020',
+  color: 'white',
+  boxShadow: 24,
+  p: 4,
+  borderRadius: '30px',
+};
+
 
 export default function TokenList() {
+
+  const [open, setOpen] = React.useState(false);
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
   const token = useMetaportStore((state) => state.token)
   const tokens = useMetaportStore((state) => state.tokens)
+
+  console.log('tokens;; ', tokens.erc20)
   const setToken = useMetaportStore((state) => state.setToken)
   const updateTokenBalances = useMetaportStore((state) => state.updateTokenBalances)
   const tokenContracts = useMetaportStore((state) => state.tokenContracts)
 
   const tokenBalances = useMetaportStore((state) => state.tokenBalances)
+  console.log('token balances;; ', tokenBalances)
+
   const transferInProgress = useMetaportStore((state) => state.transferInProgress)
 
   const expandedTokens = useCollapseStore((state) => state.expandedTokens)
@@ -88,6 +115,74 @@ export default function TokenList() {
   if (noTokens) {
     tokensText = 'N/A'
   }
+
+
+  return (
+    <div >
+      <Button className={cls(cmn.flex, cmn.flexcv, cmn.fullWidth)} onClick={handleOpen}>
+        <div className={cls(cmn.flex, cmn.flexc, cmn.mri10, [cmn.pDisabled, noTokens])}>
+          <TokenIcon
+            key={token?.meta.symbol}
+            tokenSymbol={token?.meta.symbol}
+            iconUrl={token?.meta.iconUrl}
+          />
+        </div>
+        <p
+          className={cls(
+            cmn.p,
+            cmn.p1,
+            cmn.p700,
+            cmn.pPrim,
+            [cmn.pDisabled, noTokens],
+            cmn.flex,
+            cmn.flexg,
+            cmn.mri10
+          )}
+        >
+          {tokensText}
+        </p>
+      </Button>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+      >
+        <Box sx={style}>
+          <TokenListSection
+            tokens={{ ...tokens.erc20, ...tokens.eth }}
+            type={dc.TokenType.erc20}
+            setToken={setToken}
+            setExpanded={setExpandedTokens}
+            tokenBalances={tokenBalances}
+            onCloseModal={handleClose}
+          />
+          <TokenListSection
+            tokens={tokens.erc721}
+            type={dc.TokenType.erc721}
+            setToken={setToken}
+            setExpanded={setExpandedTokens}
+            onCloseModal={handleClose}
+          />
+          <TokenListSection
+            tokens={tokens.erc721meta}
+            type={dc.TokenType.erc721meta}
+            setToken={setToken}
+            setExpanded={setExpandedTokens}
+            onCloseModal={handleClose}
+          />
+          <TokenListSection
+            tokens={tokens.erc1155}
+            type={dc.TokenType.erc1155}
+            setToken={setToken}
+            setExpanded={setExpandedTokens}
+            onCloseModal={handleClose}
+          />
+        </Box>
+      </Modal>
+    </div >)
+
+
 
   return (
     <Accordion
@@ -136,31 +231,36 @@ export default function TokenList() {
             setToken={setToken}
             setExpanded={setExpandedTokens}
             tokenBalances={tokenBalances}
+            onCloseModal={handleClose}
           />
           <TokenListSection
-            tokens={tokens.erc20}
+            tokens={{ ...tokens.erc20, ...tokens.eth }}
             type={dc.TokenType.erc20}
             setToken={setToken}
             setExpanded={setExpandedTokens}
             tokenBalances={tokenBalances}
+            onCloseModal={handleClose}
           />
           <TokenListSection
             tokens={tokens.erc721}
             type={dc.TokenType.erc721}
             setToken={setToken}
             setExpanded={setExpandedTokens}
+            onCloseModal={handleClose}
           />
           <TokenListSection
             tokens={tokens.erc721meta}
             type={dc.TokenType.erc721meta}
             setToken={setToken}
             setExpanded={setExpandedTokens}
+            onCloseModal={handleClose}
           />
           <TokenListSection
             tokens={tokens.erc1155}
             type={dc.TokenType.erc1155}
             setToken={setToken}
             setExpanded={setExpandedTokens}
+            onCloseModal={handleClose}
           />
         </AccordionDetails>
       ) : null}

--- a/packages/metaport/src/components/TokenListSection.tsx
+++ b/packages/metaport/src/components/TokenListSection.tsx
@@ -2,6 +2,7 @@ import Button from '@mui/material/Button'
 import { dc, types } from '@/core'
 
 import { cls, cmn } from '../core/css'
+import { styles } from '../core/css' // Import styles
 
 import TokenBalance from './TokenBalance'
 import TokenIcon from './TokenIcon'
@@ -14,65 +15,178 @@ export default function TokenListSection(props: {
   tokens: types.mp.TokenDataMap
   type: dc.TokenType
   tokenBalances?: types.mp.TokenBalancesMap
+  onCloseModal?: () => void
 }) {
   function handle(tokenData: dc.TokenData): void {
     props.setExpanded(false)
     props.setToken(tokenData)
+    if (props.onCloseModal) props.onCloseModal()
   }
+
+  console.log('Tokens:', props.tokens);
+  console.log('Token Balances:', props.tokenBalances);
 
   if (Object.keys(props.tokens).length === 0) return
 
+  const nonZeroBalanceTokens = Object.keys(props.tokens).filter(
+    (key) =>
+      props.tokenBalances &&
+      props.tokenBalances[props.tokens[key]?.keyname] > 0n
+  )
+
+  const zeroBalanceTokens = Object.keys(props.tokens).filter(
+    (key) =>
+      !props.tokenBalances ||
+      props.tokenBalances[props.tokens[key]?.keyname] <= 0n
+  )
+
   return (
     <div className={cls(cmn.chainsList, cmn.mbott10, cmn.mri10)} style={{ marginLeft: '8px' }}>
-      <p
-        className={cls(cmn.flex, cmn.upp, cmn.p4, cmn.p, cmn.pSec, cmn.flexg, cmn.mbott10)}
-        style={{ marginLeft: '16px' }}
-      >
-        {props.type}
-      </p>
-      {Object.keys(props.tokens)
-        .sort()
-        .map((key, _) => (
-          <Button
-            key={key}
-            color="secondary"
-            size="small"
-            className={cmn.fullWidth}
-            onClick={() => handle(props.tokens[key])}
-          >
-            <div className={cls(cmn.flex, cmn.flexcv, cmn.fullWidth, cmn.mtop10, cmn.mbott10)}>
-              <div className={cls(cmn.flex, cmn.flexc, cmn.mleft10)}>
-                <TokenIcon
-                  tokenSymbol={props.tokens[key]?.meta.symbol}
-                  iconUrl={props.tokens[key]?.meta.iconUrl}
-                />
+      {nonZeroBalanceTokens.length > 0 && (
+        <div>
+          <h5 style={{ color: 'lightgrey', textAlign: 'left', fontFamily: '-apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif' }}>Your Tokens</h5>
+
+          {nonZeroBalanceTokens.sort().map((key) => (
+            <Button
+              key={key}
+              color="secondary"
+              size="small"
+              className={cmn.fullWidth}
+              onClick={() => handle(props.tokens[key])}
+            >
+              {/* Removed styles.paperGrey for transparent background */}
+              <div className={cls(cmn.flex, cmn.flexcv, cmn.fullWidth, cmn.mtop10, cmn.mbott10, cmn.bordRad)}>
+                <div className={cls(cmn.flex, cmn.flexc, cmn.mleft10)}>
+                  <TokenIcon
+                    tokenSymbol={props.tokens[key]?.meta.symbol}
+                    iconUrl={props.tokens[key]?.meta.iconUrl}
+                  />
+                </div>
+                {/* Wrapped name and address in a div and added cmn.flexg */}
+                <div className={cls(cmn.flexg)}>
+                  <p
+                    className={cls(
+                      cmn.p,
+                      cmn.p3,
+                      cmn.p600,
+                      cmn.flex,
+                      cmn.mri10,
+                      cmn.mleft10
+                    )}
+                    style={{ color: 'lightgrey' }} // Added inline style for lightgrey
+                  >
+                    {getTokenName(props.tokens[key])}
+                  </p>
+
+
+                  {props.tokens[key].address &&
+                    <p
+                      className={cls(
+                        cmn.p,
+                        cmn.p4,
+                        cmn.p500,
+                        cmn.flex,
+                        cmn.mleft10
+                      )}
+                      style={{ color: 'lightgrey', textAlign: 'right' }} // Added inline style for lightgrey and text alignment
+                    >
+                      {props.tokens[key].address.substring(0, 5) +
+                        '...' +
+                        props.tokens[key].address.substring(props.tokens[key].address.length - 3)}
+                    </p>}
+
+                </div>
+                {/* TokenBalance remains in its div */}
+                <div className={cmn.mri10}>
+                  <TokenBalance
+                    balance={
+                      props.tokenBalances ? props.tokenBalances[props.tokens[key]?.keyname] : null
+
+                    }
+                    symbol={props.tokens[key]?.meta.symbol}
+                    decimals={props.tokens[key]?.meta.decimals}
+                    style={{ color: 'lightgrey', textAlign: 'right' }} // Added inline style for lightgrey and text alignment
+                  />
+
+                </div>
+
               </div>
-              <p
-                className={cls(
-                  cmn.p,
-                  cmn.p3,
-                  cmn.p600,
-                  cmn.pPrim,
-                  cmn.flex,
-                  cmn.flexg,
-                  cmn.mri10,
-                  cmn.mleft10
-                )}
-              >
-                {getTokenName(props.tokens[key])}
-              </p>
-              <div className={cmn.mri10}>
-                <TokenBalance
-                  balance={
-                    props.tokenBalances ? props.tokenBalances[props.tokens[key]?.keyname] : null
-                  }
-                  symbol={props.tokens[key]?.meta.symbol}
-                  decimals={props.tokens[key]?.meta.decimals}
-                />
+            </Button>
+          ))}
+        </div>
+      )}
+
+      {zeroBalanceTokens.length > 0 && (
+        <div>
+          <h5 style={{ color: 'lightgrey', textAlign: 'left', fontFamily: '-apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif' }}>Tokens</h5>
+          {zeroBalanceTokens.sort().map((key) => (
+            <Button
+              key={key}
+              color="secondary"
+              size="small"
+              className={cmn.fullWidth}
+              onClick={() => handle(props.tokens[key])}
+            >
+              {/* Removed styles.paperGrey for transparent background */}
+              <div className={cls(cmn.flex, cmn.flexcv, cmn.fullWidth, cmn.mtop10, cmn.mbott10, cmn.bordRad)}>
+                <div className={cls(cmn.flex, cmn.flexc, cmn.mleft10)}>
+                  <TokenIcon
+                    tokenSymbol={props.tokens[key]?.meta.symbol}
+                    iconUrl={props.tokens[key]?.meta.iconUrl}
+                  />
+                </div>
+                 {/* Wrapped name and address in a div and added cmn.flexg */}
+                <div className={cls(cmn.flexg)}>
+                  <p
+                    className={cls(
+                      cmn.p,
+                      cmn.p3,
+                      cmn.p600,
+                      cmn.flex,
+                      cmn.mri10,
+                      cmn.mleft10
+                    )}
+                    style={{ color: 'lightgrey' }} // Added inline style for lightgrey
+                  >
+                    {getTokenName(props.tokens[key])}
+                  </p>
+
+
+                  {props.tokens[key].address &&
+                    <p
+                      className={cls(
+                        cmn.p,
+                        cmn.p4,
+                        cmn.p500,
+                        cmn.flex,
+                        cmn.mleft10
+                      )}
+                      style={{ color: 'lightgrey', textAlign: 'right' }} // Added inline style for lightgrey and text alignment
+                    >
+                      {props.tokens[key].address.substring(0, 5) +
+                        '...' +
+                        props.tokens[key].address.substring(props.tokens[key].address.length - 3)}
+                    </p>}
+
+                </div>
+                {/* TokenBalance remains in its div */}
+                <div className={cmn.mri10}>
+                  <TokenBalance
+                    balance={
+                      props.tokenBalances ? props.tokenBalances[props.tokens[key]?.keyname] : null
+                    }
+                    symbol={props.tokens[key]?.meta.symbol}
+                    decimals={props.tokens[key]?.meta.decimals}
+                    style={{ color: 'lightgrey', textAlign: 'right' }} // Added style for consistency
+                  />
+
+                </div>
+
               </div>
-            </div>
-          </Button>
-        ))}
+            </Button>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/App.scss
+++ b/src/App.scss
@@ -207,38 +207,9 @@ body {
 //   }
 // }
 
-::-webkit-scrollbar-track {
-  height: 5px !important;
-}
-
-::-webkit-scrollbar-thumb {
-  background: white;
-  -webkit-box-shadow: none;
-}
-
-::-webkit-scrollbar-thumb:window-inactive {
-  background: none;
-}
-
-::-webkit-scrollbar {
-  -webkit-appearance: none;
-  width: 10px;
-}
-
-::-webkit-scrollbar-track {
-  border-radius: 10px;
-  background-color: #e1e1e125;
-}
-
-::-webkit-scrollbar-thumb {
-  border-radius: 50px;
-  border: 0px solid rgba(255, 255, 255, 0);
-  background-clip: content-box;
-  background-color: #a0a0a0;
-}
-
-body::-webkit-scrollbar {
-  display: none;
+html,
+body {
+  overflow-x: hidden;
 }
 
 .br__bottomNav {


### PR DESCRIPTION
This PR introduces several commits related to the new Portal 4.1 UI for token selection on the Bridge page.

✅ Currently Implemented:
- Tokens are now separated into “Your Tokens” and tokens with a 0 balance.
- Updated color scheme and typography 
- A new modal appears centered on the page to display the token list and closes when a token is selected.

🛠 Upcoming Commits (to be added in this PR):
- Search bar functionality.
- Icons for both token types (your tokens and tokens)
- Chips for favorite tokens.
- “Select a Token” title displayed within a styled box.
