### PR TITLE
Max approve was removed and replaced by this.amount #1093

### DIFF
--- a/packages/metaport/src/core/actions/erc20.ts
+++ b/packages/metaport/src/core/actions/erc20.ts
@@ -26,7 +26,6 @@ import { Contract } from 'ethers'
 import { dc, type types, units } from '@/core'
 
 import { findFirstWrapperChainName } from '../metaport'
-import { MAX_APPROVE_AMOUNT } from '../constants'
 
 import { Action } from '../actions/action'
 import { checkERC20Balance, checkERC20Allowance } from './checks'
@@ -59,7 +58,7 @@ export class TransferERC20S2S extends Action {
         this.token.type,
         this.token.keyname,
         erc20SAddress,
-        MAX_APPROVE_AMOUNT
+        units.toWei(this.amount, this.token.meta.decimals)
       )
       const txBlock = await sChain.provider.getBlock(approveTx.response.blockNumber)
       this.updateState('approveDone', approveTx.response.hash, txBlock.timestamp)
@@ -141,7 +140,7 @@ export class WrapERC20S extends Action {
         this.token.type,
         this.token.keyname,
         this.token.wrapper(this.chainName2) as types.AddressType,
-        MAX_APPROVE_AMOUNT
+        units.toWei(this.amount, this.token.meta.decimals)
       )
       const txBlock = await this.sChain1.provider.getBlock(approveTx.response.blockNumber)
       this.updateState('approveWrapDone', approveTx.response.hash, txBlock.timestamp)
@@ -255,7 +254,7 @@ export class TransferERC20M2S extends Action {
         this.token.type,
         this.token.keyname,
         erc20MAddress,
-        MAX_APPROVE_AMOUNT
+        units.toWei(this.amount, this.token.meta.decimals)
       )
 
       const txBlock = await mainnet.provider.getBlock(approveTx.response.blockNumber)
@@ -318,7 +317,7 @@ export class TransferERC20S2M extends Action {
         this.token.type,
         this.token.keyname,
         erc20SAddress,
-        MAX_APPROVE_AMOUNT
+        units.toWei(this.amount, this.token.meta.decimals)
       )
       const txBlock = await sChain.provider.getBlock(approveTx.response.blockNumber)
       this.updateState('approveDone', approveTx.response.hash, txBlock.timestamp)

--- a/packages/metaport/src/core/constants.ts
+++ b/packages/metaport/src/core/constants.ts
@@ -32,10 +32,6 @@ export const ICONS_BASE_URL =
 
 export const MAX_NUMBER = 2n ** 256n - 1n
 
-// tslint:disable-next-line
-export const MAX_APPROVE_AMOUNT =
-  '115792089237316195423570985008687907853269984665640564039457584007913129639935' // (2^256 - 1 )
-
 export const DEFAULT_MIN_SFUEL_WEI = 21000000000000n
 
 export const DEFAULT_ERROR_MSG = 'Ooops... Something went wrong...'


### PR DESCRIPTION
In this PR, we updated the bridge approval process by removing the use of the max approval amount. Instead, we now explicitly approve the exact transfer amount (this.amount) wherever necessary