### PR TITLE
Your favorites were move to the header

### DIFF
--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -35,6 +35,7 @@ import MoreMenu from './components/MoreMenu'
 import AccountMenu from './components/AccountMenu'
 import NetworkSwitch from './components/NetworkSwitch'
 import GetSFuel from './components/GetSFuel'
+import FavoritesButton from './components/FavoritesButton'
 
 import { Link } from 'react-router-dom'
 
@@ -63,6 +64,7 @@ export default function Header(props: { address: `0x${string}` | undefined; mpc:
           ) : null}
         </div>
         <AccountMenu address={props.address} />
+        <FavoritesButton />
         <GetSFuel mpc={props.mpc} />
         <NetworkSwitch mpc={props.mpc} />
         <HelpZen />

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -64,10 +64,10 @@ export default function Header(props: { address: `0x${string}` | undefined; mpc:
           ) : null}
         </div>
         <AccountMenu address={props.address} />
-        <FavoritesButton />
         <GetSFuel mpc={props.mpc} />
         <NetworkSwitch mpc={props.mpc} />
         <HelpZen />
+        <FavoritesButton />
         <MoreMenu />
       </Toolbar>
     </AppBar>

--- a/src/components/FavoritesButton.tsx
+++ b/src/components/FavoritesButton.tsx
@@ -1,24 +1,27 @@
-import { Box, Button, Tooltip } from '@mui/material'
+import { Box } from '@mui/material'
 import FavoriteRoundedIcon from '@mui/icons-material/FavoriteRounded'
-import { Link } from 'react-router-dom'
-import { cls, cmn, styles } from '@skalenetwork/metaport'
+import { useNavigate } from 'react-router-dom'
+import { cmn } from '@skalenetwork/metaport'
+import SkIconBtn from './SkIconBth'
 
 export default function FavoritesButton() {
+  const navigate = useNavigate()
+  
+  const handleClick = () => {
+    navigate('/ecosystem?tab=3')
+  }
+
   return (
     <Box
-       sx={{ alignItems: 'center', textAlign: 'center', display: { xs: 'none', sm: 'flex' } }}
-       className={cls(cmn.mleft5)}
+      className={cmn.mleft5}
+      sx={{ display: 'flex', alignItems: 'center', textAlign: 'center' }}
     >
-      <Tooltip arrow title="Your Favorites">
-        <Button
-          component={Link}
-          to="/ecosystem?tab=3"
-          startIcon={<FavoriteRoundedIcon />}
-          className={cls('mp__btnConnect', styles.paperGrey, cmn.pPrim, cmn.flex,)}
-        >
-          Your Favorites
-        </Button>
-      </Tooltip>
+      <SkIconBtn
+        icon={FavoriteRoundedIcon}
+        onClick={handleClick}
+        size="small"
+        tooltipTitle="Your Favorites"
+      />
     </Box>
   )
 }

--- a/src/components/FavoritesButton.tsx
+++ b/src/components/FavoritesButton.tsx
@@ -1,0 +1,24 @@
+import { Box, Button, Tooltip } from '@mui/material'
+import FavoriteRoundedIcon from '@mui/icons-material/FavoriteRounded'
+import { Link } from 'react-router-dom'
+import { cls, cmn, styles } from '@skalenetwork/metaport'
+
+export default function FavoritesButton() {
+  return (
+    <Box
+       sx={{ alignItems: 'center', textAlign: 'center', display: { xs: 'none', sm: 'flex' } }}
+       className={cls(cmn.mleft5)}
+    >
+      <Tooltip arrow title="Your Favorites">
+        <Button
+          component={Link}
+          to="/ecosystem?tab=3"
+          startIcon={<FavoriteRoundedIcon />}
+          className={cls('mp__btnConnect', styles.paperGrey, cmn.pPrim, cmn.flex,)}
+        >
+          Your Favorites
+        </Button>
+      </Tooltip>
+    </Box>
+  )
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -33,7 +33,6 @@ import Headline from '../components/Headline'
 import PageCard from '../components/PageCard'
 import CategoryCardsGrid from '../components/ecosystem/CategoryCardsGrid'
 import NewApps from '../components/ecosystem/tabs/NewApps'
-import FavoriteApps from '../components/ecosystem/tabs/FavoriteApps'
 import TrendingApps from '../components/ecosystem/tabs/TrendingApps'
 
 import { SKALE_SOCIAL_LINKS } from '../core/constants'
@@ -54,7 +53,7 @@ export default function Home({
   metrics,
   loadData
 }: HomeProps): JSX.Element {
-  const { newApps, trendingApps, favoriteApps, isSignedIn } = useApps(chainsMeta, metrics)
+  const { newApps, trendingApps, } = useApps(chainsMeta, metrics)
 
   useEffect(() => {
     loadData()
@@ -70,23 +69,6 @@ export default function Home({
           className={cls(cmn.mbott10, cmn.mtop20)}
         />
         <ExploreSection />
-        <AppSection
-          title="Your Favorites"
-          icon={SECTION_ICONS.favorites}
-          linkTo="/ecosystem?tab=3"
-          component={
-            <FavoriteApps
-              skaleNetwork={skaleNetwork}
-              chainsMeta={chainsMeta}
-              useCarousel={true}
-              newApps={newApps}
-              filteredApps={favoriteApps}
-              trendingApps={trendingApps}
-              isSignedIn={isSignedIn}
-              error={null}
-            />
-          }
-        />
         <UserRecommendations
           skaleNetwork={skaleNetwork}
           chainsMeta={chainsMeta}


### PR DESCRIPTION
This PR moves the "Favorites" section entry point from the homepage to the global header, placing it between the "Wallet Connect" and "sFuel" buttons. Clicking this new header button now directly navigates users to the "Favorites" tab on the Ecosystem page, streamlining access to their saved items.

**🛠️ Key Changes**
**Homepage:** Removed original "Favorites" section display.
**Header:** A heart icon between Wallet Connect and Fuel was added.
**Navigation:** Configured heart icon button to navigate to the favorites tab in the ecosystem page.