### PR TITLE
New featured dApps branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "portal",
   "private": true,
-  "version": "4.0.0",
+  "version": "4.0.1",
   "type": "module",
   "scripts": {
     "build:testnet": "NETWORK_NAME=testnet bash scripts/build.sh",

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -47,7 +47,7 @@ export const TRANSFER_ERROR_MSG = 'Error during the transfer'
 export const TRANSACTION_ERROR_MSG = 'Transaction sending failed'
 
 export const BASE_METADATA_URL =
-  'https://raw.githubusercontent.com/skalenetwork/skale-network/master/metadata/'
+   'https://raw.githubusercontent.com/skalenetwork/skale-network/featured-dapps/metadata/'
 
 export const BASE_TOKEN_ICON_URL =
   'https://raw.githubusercontent.com/skalenetwork/skale-network/refs/heads/master/assets/token-icons/'

--- a/packages/core/src/types/ChainsMetadata.ts
+++ b/packages/core/src/types/ChainsMetadata.ts
@@ -45,6 +45,7 @@ export interface AppMetadata {
   added?: number
   categories: CategoriesMap
   pretge?: TimeRange
+  featured?: boolean
 }
 
 interface TimeRange {

--- a/src/App.scss
+++ b/src/App.scss
@@ -821,6 +821,16 @@ input[type=number] {
   }
 }
 
+.chipFeatured {
+
+
+   background: linear-gradient(180deg, #ff7e91, #e63946) !important;
+
+   p {
+     color: black !important
+   }
+ }
+
 .chipMostLiked {
   background: linear-gradient(180deg, #e8a25b, #e58e36) !important;
 

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -61,6 +61,10 @@ export const ChipNew: React.FC<{}> = ({}) => {
   return <Chip label="NEW" className={cls(cmn.mleft5, 'chipNewApp', 'chipXs')} />
 }
 
+export const ChipFeatured: React.FC<{}> = ({}) => {
+   return <Chip label="Featured" className={cls(cmn.mleft5, 'chipFeatured', 'chipXs')} />
+ }
+
 export const ChipPreTge: React.FC<{}> = ({}) => {
   return <Chip label="Pre-TGE" className={cls(cmn.mleft5, 'chipPreTge', 'chipXs')} />
 }

--- a/src/components/HomeComponents.tsx
+++ b/src/components/HomeComponents.tsx
@@ -30,6 +30,9 @@ import LinkRoundedIcon from '@mui/icons-material/LinkRounded'
 import PieChartOutlineRoundedIcon from '@mui/icons-material/PieChartOutlineRounded'
 import OutboundRoundedIcon from '@mui/icons-material/OutboundRounded'
 import PeopleRoundedIcon from '@mui/icons-material/PeopleRounded'
+import AppShortcutIcon from '@mui/icons-material/AppShortcut'
+
+
 
 interface SectionIcons {
   [key: string]: JSX.Element
@@ -41,7 +44,8 @@ export const SECTION_ICONS: SectionIcons = {
   new: <StarRoundedIcon color="primary" />,
   trending: <TrendingUpRoundedIcon color="primary" />,
   mostLiked: <PeopleRoundedIcon color="primary" />,
-  categories: <OutboundRoundedIcon color="primary" />
+  categories: <OutboundRoundedIcon color="primary" />,
+  featured: <AppShortcutIcon color="primary" />
 }
 
 interface ExploreCard {

--- a/src/components/chains/tabs/ChainTabsSection.tsx
+++ b/src/components/chains/tabs/ChainTabsSection.tsx
@@ -32,10 +32,11 @@ import PlaylistAddCheckCircleRoundedIcon from '@mui/icons-material/PlaylistAddCh
 import AccountBalanceWalletRoundedIcon from '@mui/icons-material/AccountBalanceWalletRounded'
 
 import ChainTabs from './Tabs'
-import HubApps from '../HubApps'
 import DeveloperInfo from './DeveloperInfo'
 import Tokens from './Tokens'
 import VerifiedContracts from './VerifiedContracts'
+import FeaturedApps from '../../ecosystem/tabs/FeaturedApps'
+import { useApps } from '../../../useApps'
 
 const BASE_TABS = [
   {
@@ -80,7 +81,11 @@ export default function ChainTabsSection(props: {
   const network = props.mpc.config.skaleNetwork
   const chainMeta = props.chainsMeta[props.schainName]
 
-  const explorerUrl = explorer.getExplorerUrl(network, props.schainName)
+  const { featuredApps, newApps, trendingApps } = useApps(props.chainsMeta, null)
+
+  const chainFeaturedApps = featuredApps.filter(app => app.chain === props.schainName)
+  
+   const explorerUrl = explorer.getExplorerUrl(network, props.schainName)
 
   const BASE_TABS_CONTENT = [
     <DeveloperInfo schainName={props.schainName} skaleNetwork={network} />,
@@ -101,15 +106,18 @@ export default function ChainTabsSection(props: {
       currentTabs.unshift({ label: 'Tokens', icon: <AccountBalanceWalletRoundedIcon /> })
       currentTabsContent.unshift(<Tokens mpc={props.mpc} schainName={props.schainName} />)
     }
-    if (props.chainsMeta[props.schainName] && props.chainsMeta[props.schainName].apps) {
-      currentTabs.unshift({ label: 'Apps', icon: <WidgetsRoundedIcon /> })
-      currentTabsContent.unshift(
-        <SkPaper gray className={cls(cmn.mtop20)}>
-          <div className={cls(cmn.mtop20, cmn.mleft5, cmn.mri5)}>
-            <HubApps
-              skaleNetwork={network}
-              chainsMeta={props.chainsMeta}
-              schainName={props.schainName}
+   if (props.chainsMeta[props.schainName] && props.chainsMeta[props.schainName].apps && chainFeaturedApps.length > 0) {
+       currentTabs.unshift({ label: 'Featured Apps', icon: <WidgetsRoundedIcon /> })
+       currentTabsContent.unshift(
+         <SkPaper gray className={cls(cmn.mtop20)}>
+           <div className={cls(cmn.mtop20, cmn.mleft5, cmn.mri5)}>
+             <FeaturedApps
+               featuredApps={chainFeaturedApps}
+               skaleNetwork={network}
+               chainsMeta={props.chainsMeta}
+               newApps={newApps}
+               trendingApps={trendingApps}
+               useCarousel={false}
             />
           </div>
         </SkPaper>

--- a/src/components/ecosystem/AppCardV2.tsx
+++ b/src/components/ecosystem/AppCardV2.tsx
@@ -31,7 +31,7 @@ import { MAINNET_CHAIN_LOGOS, OFFCHAIN_APP } from '../../core/constants'
 import CollapsibleDescription from '../CollapsibleDescription'
 import CategoriesChips from './CategoriesChips'
 import SocialButtons from './Socials'
-import { ChipNew, ChipPreTge, ChipTrending } from '../Chip'
+import { ChipNew, ChipPreTge, ChipTrending, ChipFeatured } from '../Chip'
 
 export default function AppCard(props: {
   skaleNetwork: types.SkaleNetwork
@@ -41,6 +41,7 @@ export default function AppCard(props: {
   transactions?: number
   newApps?: types.AppWithChainAndName[]
   isNew?: boolean
+  isFeatured?: boolean
   mostLiked?: number
   trending?: boolean
   gray?: boolean
@@ -54,6 +55,15 @@ export default function AppCard(props: {
   if (!appMeta) return
 
   const appDescription = appMeta.description ?? 'No description'
+
+  const statusChips = []
+   if (props.isFeatured) statusChips.push(<ChipFeatured key="featured" />)
+   if (props.trending) statusChips.push(<ChipTrending key="trending" />)
+   if (props.isNew) statusChips.push(<ChipNew key="new" />)
+   if (metadata.isPreTge(appMeta)) statusChips.push(<ChipPreTge key="pretge" />)
+
+   const maxStatusChips = 2
+   const visibleStatusChips = statusChips.slice(0, maxStatusChips)
 
   return (
     <SkPaper gray={gray} fullHeight className="sk-app-card">
@@ -82,12 +92,12 @@ export default function AppCard(props: {
           )}
         </div>
         <div className={cls(cmn.flex, cmn.flexcv, cmn.mtop10)}>
-          <p className={cls(cmn.p, cmn.pPrim, cmn.p600, cmn.p1, 'shortP', cmn.flexg)}>
-            {metadata.getAlias(props.chainsMeta, props.schainName, props.appName)}
-          </p>
-          {props.trending && <ChipTrending />}
-          {props.isNew && <ChipNew />}
-          {metadata.isPreTge(appMeta) && <ChipPreTge />}
+            <p className={cls(cmn.p, cmn.pPrim, cmn.p600, cmn.p1, 'shortP', cmn.flexg, cmn.mri10)}>
+             {metadata.getAlias(props.chainsMeta, props.schainName, props.appName)}
+           </p>
+           <div className={cls(cmn.flex, cmn.flexcv)}>
+             {visibleStatusChips}
+           </div>
         </div>
         <CollapsibleDescription text={appDescription} />
         <CategoriesChips categories={appMeta.categories} className={cls(cmn.mtop20)} />

--- a/src/components/ecosystem/CategoriesChips.tsx
+++ b/src/components/ecosystem/CategoriesChips.tsx
@@ -81,9 +81,10 @@ const CategoriesChips: React.FC<CategoriesChipsProps> = ({ categories, all, clas
 
   if (chips.length === 0) return null
 
-  const visibleChips = all ? chips : chips.slice(0, 2)
-  const remainingChips = chips.length - 2
-
+  const maxChips = 2
+   const visibleChips = all ? chips : chips.slice(0, maxChips)
+   const remainingChips = chips.length - maxChips
+   
   return (
     <Box className={cls(`chipContainer ${className}`, ['flex-w', all])}>
       {visibleChips}

--- a/src/components/ecosystem/tabs/AllApps.tsx
+++ b/src/components/ecosystem/tabs/AllApps.tsx
@@ -27,7 +27,7 @@ import { type types } from '@/core'
 import { useLikedApps } from '../../../LikedAppsContext'
 import AppCardV2 from '../AppCardV2'
 import { Grid } from '@mui/material'
-import { isNewApp, isTrending } from '../../../core/ecosystem/utils'
+import { isNewApp, isTrending, isFeatured } from '../../../core/ecosystem/utils'
 import Loader from '../../Loader'
 
 interface AllAppsProps {
@@ -37,6 +37,8 @@ interface AllAppsProps {
   newApps: types.AppWithChainAndName[]
   loaded: boolean
   trendingApps: types.AppWithChainAndName[]
+  featuredApps: types.AppWithChainAndName[]
+
 }
 
 const AllApps: React.FC<AllAppsProps> = ({
@@ -45,7 +47,9 @@ const AllApps: React.FC<AllAppsProps> = ({
   apps,
   newApps,
   loaded,
-  trendingApps
+  trendingApps,
+  featuredApps
+
 }) => {
   const { getMostLikedApps, getAppId, getMostLikedRank } = useLikedApps()
 
@@ -78,6 +82,7 @@ const AllApps: React.FC<AllAppsProps> = ({
               mostLiked={getMostLikedRank(mostLikedAppIds, appId)}
               trending={isTrending(trendingApps, app.chain, app.appName)}
               isNew={isNew}
+              isFeatured={isFeatured({ chain: app.chain, app: app.appName }, featuredApps)}
             />
           </Grid>
         )

--- a/src/components/ecosystem/tabs/FavoriteApps.tsx
+++ b/src/components/ecosystem/tabs/FavoriteApps.tsx
@@ -31,7 +31,7 @@ import { cls, cmn, SkPaper } from '@skalenetwork/metaport'
 import Carousel from '../../Carousel'
 import ConnectWallet from '../../ConnectWallet'
 import { Link } from 'react-router-dom'
-import { isNewApp, isTrending } from '../../../core/ecosystem/utils'
+import { isFeatured, isNewApp, isTrending } from '../../../core/ecosystem/utils'
 
 export default function FavoriteApps(props: {
   skaleNetwork: types.SkaleNetwork
@@ -40,6 +40,7 @@ export default function FavoriteApps(props: {
   newApps: types.AppWithChainAndName[]
   filteredApps: types.AppWithChainAndName[]
   trendingApps: types.AppWithChainAndName[]
+  featuredApps: types.AppWithChainAndName[]
   isSignedIn: boolean
   error: string | null
 }) {
@@ -52,6 +53,8 @@ export default function FavoriteApps(props: {
   const appCards = props.filteredApps.map((app) => {
     const mostLikedRank = getMostLikedRank(mostLikedAppIds, getAppId(app.chain, app.appName))
     const isNew = isNewApp({ chain: app.chain, app: app.appName }, props.newApps)
+    const isFeaturedApps = isFeatured({ chain: app.chain, app: app.appName }, props.featuredApps)
+
     return (
       <Grid
         key={`${app.appName}-${app.chain}`}
@@ -71,6 +74,8 @@ export default function FavoriteApps(props: {
           isNew={isNew}
           mostLiked={mostLikedRank}
           trending={isTrending(props.trendingApps, app.chain, app.appName)}
+          isFeatured={isFeaturedApps}
+
         />
       </Grid>
     )

--- a/src/components/ecosystem/tabs/FeaturedApps.tsx
+++ b/src/components/ecosystem/tabs/FeaturedApps.tsx
@@ -1,0 +1,119 @@
+/**
+  * @license
+  * SKALE portal
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU Affero General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+
+
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  * GNU Affero General Public License for more details.
+  *
+  * You should have received a copy of the GNU Affero General Public License
+  * along with this program. If not, see <https://www.gnu.org/licenses/>.
+  */
+ /**
+  * @file FeaturedApps.tsx
+  * @copyright SKALE Labs 2025-Present
+  */
+
+ import React, { useMemo } from 'react'
+ import { Grid, Box } from '@mui/material'
+ import { cls, cmn, SkPaper } from '@skalenetwork/metaport'
+ import AppCard from '../AppCardV2'
+ import Carousel from '../../Carousel'
+ import { type types } from '@/core'
+ import { useLikedApps } from '../../../LikedAppsContext'
+ import { isTrending } from '../../../core/ecosystem/utils'
+ import { isNewApp } from '../../../core/ecosystem/utils'
+
+
+
+ interface FeaturedAppsProps {
+   featuredApps: types.AppWithChainAndName[]
+   skaleNetwork: types.SkaleNetwork
+   chainsMeta: types.ChainsMetadataMap
+   trendingApps: types.AppWithChainAndName[]
+   newApps: types.AppWithChainAndName[]
+   useCarousel?: boolean
+ }
+
+ const FeaturedApps: React.FC<FeaturedAppsProps> = ({
+   featuredApps,
+   skaleNetwork,
+   chainsMeta,
+   newApps,
+   trendingApps,
+   useCarousel = false
+
+ }) => {
+   console.log('Featured Apps Prop:', featuredApps); 
+   console.log('Chains Meta:', chainsMeta); 
+
+   const { getMostLikedApps, getAppId, getMostLikedRank } = useLikedApps()
+   const trendingAppIds = useMemo(() => getMostLikedApps(), [getMostLikedApps])
+   const filteredFeaturedApps = useMemo(() => {
+     const filtered = featuredApps.filter((app) => {
+       const chainData = chainsMeta[app.chain]?.apps?.[app.appName];
+       return chainData?.featured === true;
+     });
+     console.log('Filtered Featured Apps:', filtered);
+     return filtered;
+   }, [featuredApps, chainsMeta]);
+   console.log('Featured Apps:', featuredApps);
+   console.log('Chains Meta:', chainsMeta);
+
+   const renderAppCard = (app: types.AppWithChainAndName) => {
+     const isNew = isNewApp({ chain: app.chain, app: app.appName }, newApps)
+     const appId = getAppId(app.chain, app.appName)
+     console.log('Rendering AppCard for:', app); 
+
+     return (
+       <AppCard
+         key={`${app.chain}-${app.appName}`}
+         skaleNetwork={skaleNetwork}
+         schainName={app.chain}
+         appName={app.appName}
+         chainsMeta={chainsMeta}
+         mostLiked={getMostLikedRank(trendingAppIds, appId)}
+         trending={isTrending(trendingApps, app.chain, app.appName)}
+         isNew={isNew}
+         isFeatured={true}
+
+       />
+     )
+   }
+
+   if (useCarousel) {
+     return <Carousel>{featuredApps.map(renderAppCard)}</Carousel>
+   }
+
+   if (featuredApps.length === 0) {
+     return (
+       <SkPaper gray className="titleSection">
+         <div className={cls(cmn.mtop20, cmn.mbott20)}>
+           <p className={cls(cmn.p, cmn.p3, cmn.pSec, cmn.pCent)}>
+             No featured apps match your current filters
+           </p>
+         </div>
+       </SkPaper>
+     )
+   }
+
+   return (
+     <Grid container spacing={2}>
+       {filteredFeaturedApps.map((app) => (
+         <Grid key={`${app.chain}-${app.appName}`} item xs={12} sm={6} md={4} lg={4}>
+           <Box className={cls('fl-centered dappCard')}>{renderAppCard(app)}</Box>
+         </Grid>
+       ))}
+     </Grid>
+   )
+ }
+
+ export default FeaturedApps

--- a/src/components/ecosystem/tabs/NewApps.tsx
+++ b/src/components/ecosystem/tabs/NewApps.tsx
@@ -27,13 +27,14 @@ import AppCard from '../AppCardV2'
 import Carousel from '../../Carousel'
 import { type types } from '@/core'
 import { useLikedApps } from '../../../LikedAppsContext'
-import { isTrending } from '../../../core/ecosystem/utils'
+import { isTrending, isFeatured } from '../../../core/ecosystem/utils'
 
 interface NewAppsProps {
   newApps: types.AppWithChainAndName[]
   skaleNetwork: types.SkaleNetwork
   chainsMeta: types.ChainsMetadataMap
   trendingApps: types.AppWithChainAndName[]
+  featuredApps: types.AppWithChainAndName[]
   useCarousel?: boolean
 }
 
@@ -42,6 +43,7 @@ const NewApps: React.FC<NewAppsProps> = ({
   skaleNetwork,
   chainsMeta,
   trendingApps,
+  featuredApps,
   useCarousel = false
 }) => {
   const { getMostLikedApps, getAppId, getMostLikedRank } = useLikedApps()
@@ -58,6 +60,7 @@ const NewApps: React.FC<NewAppsProps> = ({
         chainsMeta={chainsMeta}
         mostLiked={getMostLikedRank(trendingAppIds, appId)}
         trending={isTrending(trendingApps, app.chain, app.appName)}
+        isFeatured={isFeatured({ chain: app.chain, app: app.appName }, featuredApps)}
         isNew={true}
       />
     )

--- a/src/components/ecosystem/tabs/TrendingApps.tsx
+++ b/src/components/ecosystem/tabs/TrendingApps.tsx
@@ -31,12 +31,14 @@ import { isNewApp } from '../../../core/ecosystem/utils'
 import { getAppMeta } from '../../../core/ecosystem/apps'
 import { useLikedApps } from '../../../LikedAppsContext'
 
+
 interface TrendingAppsProps {
   skaleNetwork: types.SkaleNetwork
   chainsMeta: types.ChainsMetadataMap
   useCarousel?: boolean
   newApps: types.AppWithChainAndName[]
   filteredApps: types.AppWithChainAndName[]
+  featuredApps: types.AppWithChainAndName[]
 }
 
 const TrendingApps: React.FC<TrendingAppsProps> = ({
@@ -44,7 +46,9 @@ const TrendingApps: React.FC<TrendingAppsProps> = ({
   chainsMeta,
   useCarousel,
   newApps,
-  filteredApps
+  filteredApps,
+  featuredApps
+
 }) => {
   const apps = useMemo(
     () => filteredApps.filter((app) => getAppMeta(chainsMeta, app.chain, app.appName)),
@@ -56,6 +60,7 @@ const TrendingApps: React.FC<TrendingAppsProps> = ({
 
   const renderAppCard = (app: types.AppWithChainAndName) => {
     const isNew = isNewApp({ chain: app.chain, app: app.appName }, newApps)
+    const isFeatured = featuredApps.some((featuredApp) => featuredApp.chain === app.chain && featuredApp.appName === app.appName)
     const appId = getAppId(app.chain, app.appName)
     return (
       <Box key={`${app.chain}-${app.appName}`} className={cls('fl-centered dappCard')}>
@@ -67,6 +72,9 @@ const TrendingApps: React.FC<TrendingAppsProps> = ({
           isNew={isNew}
           trending={true}
           mostLiked={getMostLikedRank(mostLikedAppIds, appId)}
+          isFeatured={isFeatured}
+
+
         />
       </Box>
     )

--- a/src/core/ecosystem/utils.ts
+++ b/src/core/ecosystem/utils.ts
@@ -81,7 +81,15 @@ export const getRecentApps = (
   })
   return appsWithTimestamp.sort((a, b) => b.added! - a.added!).slice(0, count)
 }
+export const isFeatured = (
 
+
+   app: { chain: string; app: string },
+   featuredApps: types.AppWithChainAndName[]
+ ): boolean => {
+   return featuredApps.some((featuredApp) => featuredApp.chain === app.chain && featuredApp.appName === app.app)
+ }
+ 
 export const isNewApp = (
   app: { chain: string; app: string },
   newApps: types.AppWithChainAndName[]

--- a/src/pages/Ecosystem.tsx
+++ b/src/pages/Ecosystem.tsx
@@ -27,6 +27,7 @@ import GridViewRoundedIcon from '@mui/icons-material/GridViewRounded'
 import FavoriteRoundedIcon from '@mui/icons-material/FavoriteRounded'
 import TrendingUpRoundedIcon from '@mui/icons-material/TrendingUpRounded'
 import StarRoundedIcon from '@mui/icons-material/StarRounded'
+import AppShortcutIcon from '@mui/icons-material/AppShortcut';
 import AddCircleOutlineRoundedIcon from '@mui/icons-material/AddCircleOutlineRounded'
 
 import { type types } from '@/core'
@@ -47,6 +48,8 @@ import FavoriteApps from '../components/ecosystem/tabs/FavoriteApps'
 import TrendingApps from '../components/ecosystem/tabs/TrendingApps'
 import SocialButtons from '../components/ecosystem/Socials'
 import SkPageInfoIcon from '../components/SkPageInfoIcon'
+import FeaturedApps from '../components/ecosystem/tabs/FeaturedApps'
+
 
 export default function Ecosystem(props: {
   mpc: MetaportCore
@@ -57,7 +60,7 @@ export default function Ecosystem(props: {
 }) {
   const { getCheckedItemsFromUrl, setCheckedItemsInUrl, getTabIndexFromUrl, setTabIndexInUrl } =
     useUrlParams()
-  const { allApps, newApps, trendingApps, favoriteApps, isSignedIn } = useApps(
+    const { allApps, newApps, trendingApps, favoriteApps, isSignedIn, featuredApps } = useApps(
     props.chainsMeta,
     props.metrics
   )
@@ -68,14 +71,15 @@ export default function Ecosystem(props: {
   const [activeTab, setActiveTab] = useState(0)
   const [loaded, setLoaded] = useState<boolean>(false)
 
-  useEffect(() => {
+ useEffect(() => {
+
+
     props.loadData()
     const initialCheckedItems = getCheckedItemsFromUrl()
     setCheckedItems(initialCheckedItems)
     const initialTabIndex = getTabIndexFromUrl()
     setActiveTab(initialTabIndex)
   }, [])
-
   useEffect(() => {
     const filtered = filterAppsBySearchTerm(
       filterAppsByCategory(allApps, checkedItems),
@@ -85,56 +89,62 @@ export default function Ecosystem(props: {
     setFilteredApps(filtered)
     setLoaded(true)
   }, [allApps, checkedItems, searchTerm, props.chainsMeta])
-
   const handleSetCheckedItems = (newCheckedItems: string[]) => {
     setCheckedItems(newCheckedItems)
     setCheckedItemsInUrl(newCheckedItems)
   }
-
   const handleTabChange = (_: React.SyntheticEvent, newValue: number) => {
     setActiveTab(newValue)
     setTabIndexInUrl(newValue)
   }
-
   const getFilteredAppsByTab = useMemo(() => {
-    const filterMap = new Map([
-      [0, filteredApps], // All Apps
-      [
-        1,
-        newApps.filter((app) =>
-          filteredApps.some(
-            (filteredApp) => filteredApp.chain === app.chain && filteredApp.appName === app.appName
-          )
-        )
-      ], // New Apps
-      [
-        2,
-        trendingApps.filter((app) =>
-          filteredApps.some(
-            (filteredApp) => filteredApp.chain === app.chain && filteredApp.appName === app.appName
-          )
-        )
-      ], // Trending Apps
-      [
-        3,
-        isSignedIn
-          ? favoriteApps.filter((app) =>
-              filteredApps.some(
+     const filterMap = new Map([
+       [0, filteredApps], // All Apps
+       [
+
+         1,
+         featuredApps.filter((app) =>
+           filteredApps.some(
+             (filteredApp) => filteredApp.chain === app.chain && filteredApp.appName === app.appName
+           )
+         )
+       ],// Featured Apps
+       [
+         2,
+       newApps.filter((app) =>
+         filteredApps.some(
+           (filteredApp) => filteredApp.chain === app.chain && filteredApp.appName === app.appName
+         )
+       )
+     ],
+       // New Apps
+       [
+         3,
+         trendingApps.filter((app) =>
+           filteredApps.some(
+             (filteredApp) => filteredApp.chain === app.chain && filteredApp.appName === app.appName
+           )
+         )
+       ], // Trending Apps
+       [
+         4,
+         isSignedIn
+           ? favoriteApps.filter((app) =>
+               filteredApps.some(
                 (filteredApp) =>
                   filteredApp.chain === app.chain && filteredApp.appName === app.appName
               )
             )
           : []
       ] // Favorite Apps
-    ])
+     ])
 
-    return (tabIndex: number) => filterMap.get(tabIndex) || filteredApps
-  }, [filteredApps, newApps, trendingApps, favoriteApps, isSignedIn])
+     return (tabIndex: number) => filterMap.get(tabIndex) || filteredApps
+   }, [filteredApps, newApps, trendingApps, favoriteApps, featuredApps,isSignedIn])
 
-  const currentFilteredApps = getFilteredAppsByTab(activeTab)
+   const currentFilteredApps = getFilteredAppsByTab(activeTab)
 
   const isFiltersApplied = Object.keys(checkedItems).length !== 0
-
   return (
     <Container maxWidth="md">
       <Helmet>
@@ -185,12 +195,18 @@ export default function Ecosystem(props: {
           >
             <Tab
               label="All"
-              icon={<GridViewRoundedIcon />}
-              iconPosition="start"
-              className={cls('btn', 'btnSm', cmn.mri5, 'tab', 'fwmobile')}
-            />
-            <Tab
-              label="New"
+               icon={<GridViewRoundedIcon />}
+               iconPosition="start"
+               className={cls('btn', 'btnSm', cmn.mri5, 'tab', 'fwmobile')}
+             />
+              <Tab
+               label="Featured"
+               icon={<AppShortcutIcon />}
+               iconPosition="start"
+               className={cls('btn', 'btnSm', cmn.mri5, cmn.mleft5, 'tab', 'fwmobile')}
+             />
+             <Tab
+               label="New"
               icon={<StarRoundedIcon />}
               iconPosition="start"
               className={cls('btn', 'btnSm', cmn.mri5, cmn.mleft5, 'tab', 'fwmobile')}
@@ -208,41 +224,55 @@ export default function Ecosystem(props: {
               className={cls('btn', 'btnSm', cmn.mri5, cmn.mleft5, 'tab', 'fwmobile')}
             />
           </Tabs>
-
           {activeTab === 0 && (
             <AllApps
               apps={currentFilteredApps}
               skaleNetwork={props.mpc.config.skaleNetwork}
               chainsMeta={props.chainsMeta}
-              newApps={newApps}
-              loaded={loaded}
-              trendingApps={trendingApps}
-            />
-          )}
-          {activeTab === 1 && (
-            <NewApps
-              newApps={currentFilteredApps}
-              skaleNetwork={props.mpc.config.skaleNetwork}
-              chainsMeta={props.chainsMeta}
-              trendingApps={trendingApps}
-            />
-          )}
-          {activeTab === 2 && (
-            <TrendingApps
-              chainsMeta={props.chainsMeta}
-              skaleNetwork={props.mpc.config.skaleNetwork}
-              newApps={newApps}
-              filteredApps={currentFilteredApps}
-            />
-          )}
-          {activeTab === 3 && (
-            <FavoriteApps
-              chainsMeta={props.chainsMeta}
-              skaleNetwork={props.mpc.config.skaleNetwork}
-              newApps={newApps}
-              filteredApps={currentFilteredApps}
-              trendingApps={trendingApps}
-              isSignedIn={isSignedIn}
+               newApps={newApps}
+               loaded={loaded}
+               trendingApps={trendingApps}
+               featuredApps={featuredApps}
+             />
+           )}
+              {activeTab === 1 && (
+             <FeaturedApps
+               featuredApps={currentFilteredApps}
+               newApps={newApps}
+               skaleNetwork={props.mpc.config.skaleNetwork}
+               chainsMeta={props.chainsMeta}
+               trendingApps={trendingApps}
+             />
+           )}
+           {activeTab === 2 && (
+             <NewApps
+               newApps={currentFilteredApps}
+               skaleNetwork={props.mpc.config.skaleNetwork}
+               chainsMeta={props.chainsMeta}
+               trendingApps={trendingApps}
+               featuredApps={featuredApps}
+             />
+           )}
+           {activeTab === 3 && (
+             <TrendingApps
+               chainsMeta={props.chainsMeta}
+               skaleNetwork={props.mpc.config.skaleNetwork}
+               newApps={newApps}
+               filteredApps={currentFilteredApps}
+               featuredApps={featuredApps}
+             />
+           )}
+           {activeTab === 4 && (
+             <FavoriteApps
+               chainsMeta={props.chainsMeta}
+               skaleNetwork={props.mpc.config.skaleNetwork}
+               newApps={newApps}
+                           featuredApps={featuredApps}
+
+
+               filteredApps={currentFilteredApps}
+               trendingApps={trendingApps}
+               isSignedIn={isSignedIn}
               error={null}
             />
           )}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -21,44 +21,42 @@
  * @copyright SKALE Labs 2024-Present
  */
 
-import { useEffect } from 'react'
-import { Link } from 'react-router-dom'
-import { Container, Stack, Box, Grid, Button } from '@mui/material'
-import { cmn, cls, SkPaper } from '@skalenetwork/metaport'
-import { type types } from '@/core'
+ import { useEffect } from 'react'
+ import { Link } from 'react-router-dom'
+ import { Container, Stack, Box, Grid, Button } from '@mui/material'
+ import { cmn, cls, SkPaper} from '@skalenetwork/metaport'
+ import { type types } from '@/core'
 
-import { useApps } from '../useApps'
-
+ import { useApps } from '../useApps'
 import Headline from '../components/Headline'
 import PageCard from '../components/PageCard'
 import CategoryCardsGrid from '../components/ecosystem/CategoryCardsGrid'
-import NewApps from '../components/ecosystem/tabs/NewApps'
-import TrendingApps from '../components/ecosystem/tabs/TrendingApps'
+ import NewApps from '../components/ecosystem/tabs/NewApps'
+ import FavoriteApps from '../components/ecosystem/tabs/FavoriteApps'
+ import TrendingApps from '../components/ecosystem/tabs/TrendingApps'
+ import FeaturedApps from '../components/ecosystem/tabs/FeaturedApps'
 
-import { SKALE_SOCIAL_LINKS } from '../core/constants'
-import { SECTION_ICONS, EXPLORE_CARDS } from '../components/HomeComponents'
+ import { SKALE_SOCIAL_LINKS } from '../core/constants'
+ import { SECTION_ICONS, EXPLORE_CARDS } from '../components/HomeComponents'
 import SocialButtons from '../components/ecosystem/Socials'
 import UserRecommendations from '../components/ecosystem/UserRecommendations'
-
 interface HomeProps {
   skaleNetwork: types.SkaleNetwork
   chainsMeta: types.ChainsMetadataMap
   metrics: types.IMetrics | null
   loadData: () => Promise<void>
 }
-
 export default function Home({
   skaleNetwork,
   chainsMeta,
-  metrics,
-  loadData
-}: HomeProps): JSX.Element {
-  const { newApps, trendingApps, } = useApps(chainsMeta, metrics)
+   metrics,
+   loadData
+ }: HomeProps): JSX.Element {
+   const { newApps, trendingApps, favoriteApps, isSignedIn, featuredApps } = useApps(chainsMeta, metrics)
 
-  useEffect(() => {
-    loadData()
+   useEffect(() => {
+     loadData()
   }, [])
-
   return (
     <Container maxWidth="md" className="paddBott60">
       <Stack spacing={0}>
@@ -69,37 +67,72 @@ export default function Home({
           className={cls(cmn.mbott10, cmn.mtop20)}
         />
         <ExploreSection />
-        <UserRecommendations
-          skaleNetwork={skaleNetwork}
-          chainsMeta={chainsMeta}
-          metrics={metrics}
-        />
         <AppSection
-          title="New dApps on SKALE"
-          icon={SECTION_ICONS.new}
-          linkTo="/ecosystem?tab=1"
+          title="Your Favorites"
+          icon={SECTION_ICONS.favorites}
+          linkTo="/ecosystem?tab=3"
           component={
-            <NewApps
-              newApps={newApps}
-              skaleNetwork={skaleNetwork}
-              chainsMeta={chainsMeta}
-              useCarousel={true}
-              trendingApps={trendingApps}
+            <FavoriteApps
+               skaleNetwork={skaleNetwork}
+               chainsMeta={chainsMeta}
+               useCarousel={true}
+               featuredApps={featuredApps}
+               newApps={newApps}
+               filteredApps={favoriteApps}
+               trendingApps={trendingApps}
+              isSignedIn={isSignedIn}
+              error={null}
             />
           }
         />
-        <AppSection
-          title="Trending dApps on SKALE"
-          icon={SECTION_ICONS.trending}
-          linkTo="/ecosystem?tab=2"
-          component={
-            <TrendingApps
-              chainsMeta={chainsMeta}
-              skaleNetwork={skaleNetwork}
-              newApps={newApps}
-              filteredApps={trendingApps}
-              useCarousel
-            />
+        <UserRecommendations
+          skaleNetwork={skaleNetwork}
+           chainsMeta={chainsMeta}
+           metrics={metrics}
+         />
+         <AppSection
+           title="Featured dApps on SKALE"
+           icon={SECTION_ICONS.featured}
+           linkTo="/ecosystem?tab=1"
+           component={
+             <FeaturedApps
+               featuredApps={featuredApps}
+               newApps={newApps}
+               skaleNetwork={skaleNetwork}
+               chainsMeta={chainsMeta}
+               trendingApps={trendingApps}
+               useCarousel={true}
+             />
+           }
+         />
+         <AppSection
+           title="New dApps on SKALE"
+           icon={SECTION_ICONS.new}
+           linkTo="/ecosystem?tab=2"
+           component={
+             <NewApps
+               newApps={newApps}
+               skaleNetwork={skaleNetwork}
+               chainsMeta={chainsMeta}
+               useCarousel={true}
+               trendingApps={trendingApps}
+               featuredApps={featuredApps}
+             />
+           }
+         />
+         <AppSection
+           title="Trending dApps on SKALE"
+           icon={SECTION_ICONS.trending}
+           linkTo="/ecosystem?tab=3"
+           component={
+             <TrendingApps
+               chainsMeta={chainsMeta}
+               skaleNetwork={skaleNetwork}
+               newApps={newApps}
+               featuredApps={featuredApps}
+               filteredApps={trendingApps}
+               useCarousel
+             />
           }
         />
       </Stack>
@@ -109,17 +142,16 @@ export default function Home({
         className={cls(cmn.mbott10, cmn.mtop20, cmn.ptop20)}
       />
       <CategoryCardsGrid chainsMeta={chainsMeta} />
-      <div className={cls(cmn.flex, cmn.mtop20, cmn.ptop20)}>
-        <div className={cls(cmn.flexg)}></div>
-        <SkPaper gray className={cls(cmn.mtop20)}>
-          <SocialButtons social={SKALE_SOCIAL_LINKS} size="md" className="m-ri-min10" />
-        </SkPaper>
-        <div className={cls(cmn.flexg)}></div>
-      </div>
+       <div className={cls(cmn.flex, cmn.mtop20, cmn.ptop20)}>
+         <div className={cls(cmn.flexg)}></div>
+         <SkPaper gray className={cls(cmn.mtop20)}>
+         <SocialButtons social={SKALE_SOCIAL_LINKS} size="md" className="m-ri-min10" />
+         </SkPaper>
+         <div className={cls(cmn.flexg)}></div>
+       </div>
     </Container>
   )
 }
-
 function ExploreSection(): JSX.Element {
   return (
     <Box sx={{ flexGrow: 1 }}>
@@ -133,14 +165,12 @@ function ExploreSection(): JSX.Element {
     </Box>
   )
 }
-
 interface AppSectionProps {
   title: string
   icon: JSX.Element
   linkTo: string
   component: JSX.Element
 }
-
 function AppSection({ title, icon, linkTo, component }: AppSectionProps): JSX.Element {
   return (
     <>
@@ -150,7 +180,7 @@ function AppSection({ title, icon, linkTo, component }: AppSectionProps): JSX.El
           <Button className={cls('btn btnSm bg', cmn.pPrim)}>See all</Button>
         </Link>
       </div>
-      {component}
-    </>
-  )
-}
+       {component}
+     </>
+   )
+ } 

--- a/src/useApps.tsx
+++ b/src/useApps.tsx
@@ -43,6 +43,12 @@ export function useApps(chainsMeta: types.ChainsMetadataMap, metrics: types.IMet
     return apps.sort((a, b) => a.alias.localeCompare(b.alias))
   }, [chainsMeta])
 
+  const featuredApps = useMemo<types.AppWithChainAndName[]>(() => {
+     const filteredApps = allApps.filter(app => app.featured === true)
+     console.log('Featured Apps:', filteredApps) 
+     return filteredApps
+   }, [allApps])
+
   const newApps = useMemo<types.AppWithChainAndName[]>(() => {
     const apps = getRecentApps(chainsMeta, MAX_APPS_DEFAULT)
     return apps.sort((a, b) => (b.added || 0) - (a.added || 0))
@@ -82,5 +88,6 @@ export function useApps(chainsMeta: types.ChainsMetadataMap, metrics: types.IMet
       .slice(0, MAX_APPS_DEFAULT)
   }, [allApps, metrics])
 
-  return { allApps, newApps, mostLikedApps, favoriteApps, trendingApps, isSignedIn }
+  return { allApps, featuredApps, newApps, mostLikedApps, favoriteApps, trendingApps, isSignedIn}
+
 }


### PR DESCRIPTION
This PR introduces the Featured dApps section on the Home Page, showcasing the following applications:

- For Loot and Glory
- Bit Hotel ﻿
- Calypso ﻿
- Pixudi ﻿
- Dmail ﻿
- XO ﻿
- Hello Pixel ﻿
- Sushi Swap ﻿
- QSTN ﻿
- Titan AI Hub ﻿
- Chain GPT ﻿
- PaLM AI ﻿﻿
- Skillful AI

**Additional Changes**

**Tabs Update:**
Tabs on the home page were updated to show only 2, for a cleaner UI.
-Each chain page now displays Featured Apps using a card design instead of all apps on the chain.
**Related Pages Updated:**
The following pages were modified to align with the new structure:
New
Trending
Favorites
For chains that don’t have Featured Apps, this section is not displayed.
