### PR TITLE
Fixed bug with featured dApps

### DIFF
--- a/src/components/ecosystem/RecommendedApps.tsx
+++ b/src/components/ecosystem/RecommendedApps.tsx
@@ -27,7 +27,7 @@ import { cls } from '@skalenetwork/metaport'
 
 import { type types } from '@/core'
 
-import { isNewApp, isTrending } from '../../core/ecosystem/utils'
+import { isNewApp, isTrending, isFeatured } from '../../core/ecosystem/utils'
 import { findSimilarApps, type SimilarApp } from '../../core/ecosystem/similarApps'
 
 import AppCardV2 from './AppCardV2'
@@ -42,6 +42,7 @@ interface RecommendedAppsProps {
   favoriteApps?: types.AppWithChainAndName[]
   newApps: types.AppWithChainAndName[]
   trendingApps: types.AppWithChainAndName[]
+  featuredApps?: types.AppWithChainAndName[]
   useCarousel?: boolean
   className?: string
   gray?: boolean
@@ -55,6 +56,7 @@ const RecommendedApps: React.FC<RecommendedAppsProps> = ({
   favoriteApps,
   newApps,
   trendingApps,
+  featuredApps = [],
   useCarousel = false,
   className,
   gray = false
@@ -80,6 +82,7 @@ const RecommendedApps: React.FC<RecommendedAppsProps> = ({
           isNew={isNewApp({ chain: app.chain, app: app.appName }, newApps)}
           mostLiked={getMostLikedRank(mostLikedAppIds, appId)}
           trending={isTrending(trendingApps, app.chain, app.appName)}
+          isFeatured={isFeatured({ chain: app.chain, app: app.appName }, featuredApps)}
           gray={gray}
         />
       </Box>

--- a/src/components/ecosystem/UserRecommendations.tsx
+++ b/src/components/ecosystem/UserRecommendations.tsx
@@ -38,7 +38,7 @@ const UserRecommendations: React.FC<{
   metrics: types.IMetrics | null
 }> = ({ skaleNetwork, chainsMeta, metrics }) => {
   const { isSignedIn } = useAuth()
-  const { allApps, favoriteApps, newApps, trendingApps } = useApps(chainsMeta, metrics)
+  const { allApps, favoriteApps, newApps, trendingApps, featuredApps } = useApps(chainsMeta, metrics)
 
   const showRecommendations = isSignedIn && favoriteApps.length > 0
   if (!showRecommendations) return null
@@ -57,6 +57,7 @@ const UserRecommendations: React.FC<{
         favoriteApps={favoriteApps}
         newApps={newApps}
         trendingApps={trendingApps}
+        featuredApps={featuredApps}
         useCarousel={true}
         gray
       />

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -58,14 +58,14 @@ import { useApps } from '../useApps'
 import { getAppMetaWithChainApp } from '../core/ecosystem/apps'
 import { formatNumber } from '../core/timeHelper'
 import { MAX_APPS_DEFAULT, OFFCHAIN_APP } from '../core/constants'
-import { getRecentApps, isNewApp, isTrending } from '../core/ecosystem/utils'
+import { getRecentApps, isNewApp, isTrending, isFeatured } from '../core/ecosystem/utils'
 
 import SocialButtons from '../components/ecosystem/Socials'
 import CategoriesChips from '../components/ecosystem/CategoriesChips'
 import { useLikedApps } from '../LikedAppsContext'
 import { useAuth } from '../AuthContext'
 import ErrorTile from '../components/ErrorTile'
-import { ChipNew, ChipPreTge, ChipTrending } from '../components/Chip'
+import { ChipNew, ChipPreTge, ChipTrending, ChipFeatured } from '../components/Chip'
 import AppScreenshots from '../components/ecosystem/AppScreenshots'
 import RecommendedApps from '../components/ecosystem/RecommendedApps'
 import Logo from '../components/Logo'
@@ -122,7 +122,7 @@ export default function App(props: {
 
   const appDescription = appMeta.description ?? 'No description'
 
-  const { trendingApps, allApps } = useApps(props.chainsMeta, props.metrics)
+  const { trendingApps, allApps, featuredApps } = useApps(props.chainsMeta, props.metrics)
 
   const appId = getAppId(chain, app)
   const isLiked = likedApps.includes(appId)
@@ -130,6 +130,7 @@ export default function App(props: {
 
   const isNew = isNewApp({ chain, app }, newApps)
   const trending = isTrending(trendingApps, chain, app)
+  const featured = isFeatured({ chain, app }, featuredApps)
 
   const handleToggleLike = async () => {
     if (!address) {
@@ -230,6 +231,7 @@ export default function App(props: {
                 <div className={cls(cmn.flex, cmn.flexcv)}>
                   <h2 className={cls(cmn.nom, cmn.p1)}>{appAlias}</h2>
                   <div className={cls(cmn.flex, cmn.mleft10)}>
+                    {featured && <ChipFeatured />}
                     {trending && <ChipTrending />}
                     {isNew && <ChipNew />}
                     {metadata.isPreTge(appMeta) && <ChipPreTge />}
@@ -380,6 +382,7 @@ export default function App(props: {
               currentApp={getAppMetaWithChainApp(props.chainsMeta, chain, app)}
               newApps={newApps}
               trendingApps={trendingApps}
+              featuredApps={featuredApps}
               useCarousel={true}
             />
           </AccordionSection>


### PR DESCRIPTION
**Problem:**
The “Featured” label wasn’t displayed consistently. It appeared on dApp cards on the Ecosystem homepage but was missing from individual dApp detail pages.

**This PR fixes that by:**
Ensuring the “Featured” label is now consistently shown on the dApp detail page (in the header) and in the “Discover More” section, matching its appearance on the Ecosystem main page.


