### PR TITLE
Comment out old chains in mainnet metaport config

### DIFF
--- a/config/mainnet/index.ts
+++ b/config/mainnet/index.ts
@@ -22,8 +22,8 @@ export const METAPORT_CONFIG: types.mp.Config = {
     'honorable-steel-rasalhague', // calypso hub
     'green-giddy-denebola', // nebula hub
     'affectionate-immediate-pollux', // cryptoblades
-    'wan-red-ain', // human protocol
-    'adorable-quaint-bellatrix', // streammyscreen
+    // 'wan-red-ain', // human protocol
+    // 'adorable-quaint-bellatrix', // streammyscreen
     'parallel-stormy-spica' // titan hub
   ],
   tokens: {


### PR DESCRIPTION
This pull request makes a small change to the `METAPORT_CONFIG` in `config/mainnet/index.ts`. Specifically, it comments out two entries (`wan-red-ain` and `adorable-quaint-bellatrix`) in the `chains` array, effectively disabling them while keeping their references for potential future use.