### PR TITLE
Cleared token search input on modal close

### DIFF
--- a/packages/metaport/src/components/TokenList.tsx
+++ b/packages/metaport/src/components/TokenList.tsx
@@ -43,7 +43,10 @@ export default function TokenList() {
   const [searchQuery, setSearchQuery] = useState('')
 
   const handleOpen = () => setOpen(true)
-  const handleClose = () => setOpen(false)
+  const handleClose = () => {
+    setOpen(false)
+    setSearchQuery('')
+  }
 
   const token = useMetaportStore((state) => state.token)
   const tokens = useMetaportStore((state) => state.tokens)


### PR DESCRIPTION
This PR fixes a UI bug where the token search input is not cleared after closing the token selection modal. Previously, when a user searched for a token (e.g., “SKALE”) and selected it, the search term would persist even after reopening the modal, potentially on a different chain, causing the list to remain filtered.

**Code changes:**
const handleOpen = () => setOpen(true)

const handleClose = () => {
  setOpen(false)
  setSearchQuery('')
}

**Result:**
- The search input is now reset every time the modal closes.
- Users always see an unfiltered list when reopening the modal.