### PR TITLE
Emoji didn't appeared on All Tabs When Filtering dApps and favorite filter didn't worked

### DIFF
--- a/src/components/ecosystem/tabs/FavoriteApps.tsx
+++ b/src/components/ecosystem/tabs/FavoriteApps.tsx
@@ -80,8 +80,7 @@ export default function FavoriteApps(props: {
       </Grid>
     )
   })
-  //console.log('appCards', props.app)
-  if (appCards.length === 0)
+    if (appCards.length === 0)
     return (
       <SkPaper gray className="titleSection">
         <div className={cls(cmn.mtop20, cmn.mbott20)}>

--- a/src/components/ecosystem/tabs/FavoriteApps.tsx
+++ b/src/components/ecosystem/tabs/FavoriteApps.tsx
@@ -41,6 +41,7 @@ export default function FavoriteApps(props: {
   filteredApps: types.AppWithChainAndName[]
   trendingApps: types.AppWithChainAndName[]
   featuredApps: types.AppWithChainAndName[]
+  favoriteApps: types.AppWithChainAndName[]
   isSignedIn: boolean
   error: string | null
 }) {
@@ -79,14 +80,15 @@ export default function FavoriteApps(props: {
       </Grid>
     )
   })
-
+  //console.log('appCards', props.app)
   if (appCards.length === 0)
     return (
       <SkPaper gray className="titleSection">
         <div className={cls(cmn.mtop20, cmn.mbott20)}>
           <p className={cls(cmn.p, cmn.p3, cmn.pSec, cmn.pCent)}>
-            {props.filteredApps.length === 0
-              ? "🚫 You don't have any favorites yet"
+            
+            {props.favoriteApps.length === 0
+              ? "You don't have any favorites yet"
               : '🚫 No favorite apps match your current filters'}
           </p>
           {props.useCarousel && (

--- a/src/components/ecosystem/tabs/FavoriteApps.tsx
+++ b/src/components/ecosystem/tabs/FavoriteApps.tsx
@@ -87,7 +87,7 @@ export default function FavoriteApps(props: {
           <p className={cls(cmn.p, cmn.p3, cmn.pSec, cmn.pCent)}>
             {props.filteredApps.length === 0
               ? "You don't have any favorites yet"
-              : 'No favorite apps match your current filters'}
+              : '🚫 No favorite apps match your current filters'}
           </p>
           {props.useCarousel && (
             <div className={cls(cmn.flex)}>

--- a/src/components/ecosystem/tabs/FavoriteApps.tsx
+++ b/src/components/ecosystem/tabs/FavoriteApps.tsx
@@ -86,7 +86,7 @@ export default function FavoriteApps(props: {
         <div className={cls(cmn.mtop20, cmn.mbott20)}>
           <p className={cls(cmn.p, cmn.p3, cmn.pSec, cmn.pCent)}>
             {props.filteredApps.length === 0
-              ? "You don't have any favorites yet"
+              ? "🚫 You don't have any favorites yet"
               : '🚫 No favorite apps match your current filters'}
           </p>
           {props.useCarousel && (

--- a/src/components/ecosystem/tabs/FeaturedApps.tsx
+++ b/src/components/ecosystem/tabs/FeaturedApps.tsx
@@ -90,7 +90,7 @@ const FeaturedApps: React.FC<FeaturedAppsProps> = ({
       <SkPaper gray className="titleSection">
         <div className={cls(cmn.mtop20, cmn.mbott20)}>
           <p className={cls(cmn.p, cmn.p3, cmn.pSec, cmn.pCent)}>
-            No featured apps match your current filters
+            🚫 No featured apps match your current filters
           </p>
         </div>
       </SkPaper>

--- a/src/components/ecosystem/tabs/MostLiked.tsx
+++ b/src/components/ecosystem/tabs/MostLiked.tsx
@@ -74,7 +74,7 @@ const MostLikedApps: React.FC<MostLikedAppsProps> = ({
       <SkPaper gray className="titleSection">
         <div className={cls(cmn.mtop20, cmn.mbott20)}>
           <p className={cls(cmn.p, cmn.p3, cmn.pSec, cmn.pCent)}>
-            No trending apps match your current filters
+            🚫 No trending apps match your current filters
           </p>
         </div>
       </SkPaper>

--- a/src/components/ecosystem/tabs/NewApps.tsx
+++ b/src/components/ecosystem/tabs/NewApps.tsx
@@ -75,7 +75,7 @@ const NewApps: React.FC<NewAppsProps> = ({
       <SkPaper gray className="titleSection">
         <div className={cls(cmn.mtop20, cmn.mbott20)}>
           <p className={cls(cmn.p, cmn.p3, cmn.pSec, cmn.pCent)}>
-            No new apps match your current filters
+            🚫 No new apps match your current filters
           </p>
         </div>
       </SkPaper>

--- a/src/components/ecosystem/tabs/TrendingApps.tsx
+++ b/src/components/ecosystem/tabs/TrendingApps.tsx
@@ -83,7 +83,7 @@ const TrendingApps: React.FC<TrendingAppsProps> = ({
       <SkPaper gray className="titleSection">
         <div className={cls(cmn.mtop20, cmn.mbott20)}>
           <p className={cls(cmn.p, cmn.p3, cmn.pSec, cmn.pCent)}>
-            No trending apps match your current filters
+           🚫 No trending apps match your current filters
           </p>
         </div>
       </SkPaper>

--- a/src/pages/Ecosystem.tsx
+++ b/src/pages/Ecosystem.tsx
@@ -276,6 +276,7 @@ export default function Ecosystem(props: {
                 featuredApps={featuredApps}
                 filteredApps={currentFilteredApps}
                 trendingApps={trendingApps}
+                favoriteApps={favoriteApps}
                 isSignedIn={isSignedIn}
                 error={null}
               />


### PR DESCRIPTION
Previously, only the All tab on the Ecosystem page displayed the “🚫 No … apps match your current filters” message when no search results were found. Also, in 4.0 the favorites tab filter wasn't working, and this PR fixed it.

**Version:**
Portal 4.1.0 Beta 1.0

This PR fixes that behavior for UI consistency.

The message "🚫 No ... apps match your current filters" now appears across all relevant tabs:
	•	All
	•	Featured
	•	New
	•	Trending
	•	Favorites


