### PR TITLE
Fixed changelog link on Homepage Improvements (4.1)

### DIFF
--- a/src/components/ecosystem/tabs/FavoriteApps.tsx
+++ b/src/components/ecosystem/tabs/FavoriteApps.tsx
@@ -84,7 +84,7 @@ export default function FavoriteApps(props: {
     return (
       <SkPaper gray className="titleSection">
         <div className={cls(cmn.mtop20, cmn.mbott20)}>
-          <p className={cls(cmn.p, cmn.p3, cmn.pSec, cmn.pCent)}>
+          <p className={cls(cmn.p, cmn.p2, cmn.pSec, cmn.pCent)}>
             
             {props.favoriteApps.length === 0
               ? "You don't have any favorites yet"

--- a/src/components/ecosystem/tabs/FeaturedApps.tsx
+++ b/src/components/ecosystem/tabs/FeaturedApps.tsx
@@ -89,7 +89,7 @@ const FeaturedApps: React.FC<FeaturedAppsProps> = ({
     return (
       <SkPaper gray className="titleSection">
         <div className={cls(cmn.mtop20, cmn.mbott20)}>
-          <p className={cls(cmn.p, cmn.p3, cmn.pSec, cmn.pCent)}>
+          <p className={cls(cmn.p, cmn.p2, cmn.pSec, cmn.pCent)}>
             🚫 No featured apps match your current filters
           </p>
         </div>

--- a/src/components/ecosystem/tabs/MostLiked.tsx
+++ b/src/components/ecosystem/tabs/MostLiked.tsx
@@ -73,7 +73,7 @@ const MostLikedApps: React.FC<MostLikedAppsProps> = ({
     return (
       <SkPaper gray className="titleSection">
         <div className={cls(cmn.mtop20, cmn.mbott20)}>
-          <p className={cls(cmn.p, cmn.p3, cmn.pSec, cmn.pCent)}>
+          <p className={cls(cmn.p, cmn.p2, cmn.pSec, cmn.pCent)}>
             🚫 No trending apps match your current filters
           </p>
         </div>

--- a/src/components/ecosystem/tabs/NewApps.tsx
+++ b/src/components/ecosystem/tabs/NewApps.tsx
@@ -74,7 +74,7 @@ const NewApps: React.FC<NewAppsProps> = ({
     return (
       <SkPaper gray className="titleSection">
         <div className={cls(cmn.mtop20, cmn.mbott20)}>
-          <p className={cls(cmn.p, cmn.p3, cmn.pSec, cmn.pCent)}>
+          <p className={cls(cmn.p, cmn.p2, cmn.pSec, cmn.pCent)}>
             🚫 No new apps match your current filters
           </p>
         </div>

--- a/src/components/ecosystem/tabs/TrendingApps.tsx
+++ b/src/components/ecosystem/tabs/TrendingApps.tsx
@@ -82,7 +82,7 @@ const TrendingApps: React.FC<TrendingAppsProps> = ({
     return (
       <SkPaper gray className="titleSection">
         <div className={cls(cmn.mtop20, cmn.mbott20)}>
-          <p className={cls(cmn.p, cmn.p3, cmn.pSec, cmn.pCent)}>
+          <p className={cls(cmn.p, cmn.p2, cmn.pSec, cmn.pCent)}>
            🚫 No trending apps match your current filters
           </p>
         </div>

--- a/src/data/changelog.mdx
+++ b/src/data/changelog.mdx
@@ -18,7 +18,7 @@ Token approvals now match your intended transfer amount instead of defaulting to
 The homepage now features a refreshed UI! We’ve added a dynamic banner highlighting popular actions that change over time, plus four more action tiles.
 Favorites have been moved to a button at the top of the page, and featured dApps are now displayed on each chain as well.
 
-[Check it out](/home)
+[Check it out](/)
 
 ## 👨‍💻 Portal 4.0
 > A optimized development with the Portal, Metaport & IMA-JS merged into one!


### PR DESCRIPTION
This PR includes two small fixes:
✅ Fixed the broken link for Homepage Improvements in the 4.1 Release changelog.
✅ Adjusted the text size for the "No ... apps match your current filters" message on the Homepage, ensuring consistent text size across all tabs when no filtered dApps are found.