### PR TITLE
Link for popular actions and for Swap on SKALE changed

### DIFF
--- a/src/components/HomeComponents.tsx
+++ b/src/components/HomeComponents.tsx
@@ -76,7 +76,7 @@ export const EXPLORE_CARDS: ExploreCard[] = [
   {
     name: 'Swap on SKALE',
     description: 'Swap your favorite tokens on SKALE with zero gas fees using SushiSwap.',
-    url: '/ecosystem/europa/sushiswap',
+    url: 'https://www.sushi.com/ethereum/swap',
     icon: <SwapHorizontalCircleOutlinedIcon />
   }
 ]

--- a/src/components/PopularActions.tsx
+++ b/src/components/PopularActions.tsx
@@ -67,7 +67,7 @@ export default function PopularActions(props: {
           {actions.map((action) => (
             <Grid item xs={12} md={6}>
               <Link
-                to={`/ecosystem/${shortAlias}/${action.app}`}
+                to={chainMeta?.apps?.[action.app]?.social?.website || `/ecosystem/${shortAlias}/${action.app}`}
                 className={cls(cmn.flex, cmn.fullWidth)}
               >
                 <SkPaper gray className={cls(cmn.fullWidth, 'hoverable')} key={action.text}>


### PR DESCRIPTION
As Sawyer requested, we updated the link for the popular action ‘Swap on SKALE.’ Now, instead of linking to the dApp page on the Ecosystem, it directs to the swap page inside the Portal.