### PR TITLE
Different Lenght on Choose the Chains

### DIFF
--- a/packages/metaport/src/components/BridgeChainCard.tsx
+++ b/packages/metaport/src/components/BridgeChainCard.tsx
@@ -63,6 +63,7 @@ export default function BridgeChainCard(props: ChainCardProps) {
         className={cls(
           cmn.flex,
           cmn.flexc,
+          cmn.flexcv,
           cmn.mtop10,
           [cmn.pointer, !disabled],
           [styles.disabledCard, disabled]


### PR DESCRIPTION
**Problem:** 
The height of the "Calypso Hub", "Destination Chain", and "Source Chain" elements was different from the other chain elements.

**Fix:**
We fixed this problem in this PR