### PR TITLE
See More Button implemented with chains filter

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -409,11 +409,17 @@ body {
   height: 40px;
   transition: opacity 0.3s ease-in-out;
 
+.MuiSvgIcon-root {
+  color: #93b8ec;
+  font-size: 1.2rem;
+  }
+}
+
+.seeMoreButton {
   .MuiSvgIcon-root {
     color: #93b8ec;
-    font-size: 1.2rem;
   }
-
+    color: #93b8ec;
 }
 
 .btn {

--- a/src/components/chains/tabs/ChainTabsSection.tsx
+++ b/src/components/chains/tabs/ChainTabsSection.tsx
@@ -123,6 +123,8 @@ export default function ChainTabsSection(props: {
               trendingApps={trendingApps}
               useCarousel={false}
               gray={false}
+              showSeeMoreButton={true}
+              schainName={props.schainName}
             />
           </div>
         </SkPaper>

--- a/src/components/ecosystem/SelectedCategories.tsx
+++ b/src/components/ecosystem/SelectedCategories.tsx
@@ -26,10 +26,14 @@ import { cmn, cls, styles } from '@skalenetwork/metaport'
 import { Chip, Box } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 import { categories } from '../../core/ecosystem/categories'
+import { type types, metadata } from '@/core'
 
 interface SelectedCategoriesProps {
   checkedItems: string[]
   setCheckedItems: (items: string[]) => void
+  selectedChains: string[]
+  setSelectedChains: (chains: string[]) => void
+  chainsMeta: types.ChainsMetadataMap
   filteredAppsCount: number
 }
 
@@ -58,14 +62,22 @@ const CustomChipLabel: React.FC<{ category: string; subcategory?: string }> = ({
 const SelectedCategories: React.FC<SelectedCategoriesProps> = ({
   checkedItems,
   setCheckedItems,
+  selectedChains,
+  setSelectedChains,
+  chainsMeta,
   filteredAppsCount
 }) => {
   const handleDelete = (itemToDelete: string) => {
     setCheckedItems(checkedItems.filter((item) => item !== itemToDelete))
   }
 
+  const handleDeleteChain = (chainToDelete: string) => {
+    setSelectedChains(selectedChains.filter((chain) => chain !== chainToDelete))
+  }
+
   const clearAll = () => {
     setCheckedItems([])
+    setSelectedChains([])
   }
 
   const getCategoryName = (key: string): string => categories[key]?.name || key
@@ -82,10 +94,30 @@ const SelectedCategories: React.FC<SelectedCategoriesProps> = ({
     return subcategoryKey
   }
 
-  if (checkedItems.length === 0) return null
+  const getChainDisplayName = (chainName: string): string => {
+    return metadata.getAlias(chainsMeta, chainName) || chainName
+  }
+
+  if (checkedItems.length === 0 && selectedChains.length === 0) return null
 
   return (
     <Box className={cls(cmn.flex, cmn.flexcv, 'flex-w', cmn.mbottf10)}>
+      {selectedChains.map((chain) => (
+        <Chip
+          variant="outlined"
+          key={`chain-${chain}`}
+          label={
+            <Box display="flex" alignItems="center">
+              <p className={cls(cmn.pPrim, cmn.p, cmn.p3, cmn.p600)}>
+                {getChainDisplayName(chain)}
+              </p>
+            </Box>
+          }
+          onDelete={() => handleDeleteChain(chain)}
+          deleteIcon={<CloseIcon className={cls(styles.chainIconxs)} />}
+          className={cls('outlined', cmn.p600)}
+        />
+      ))}
       {checkedItems.map((item) => {
         const [category, subcategory] = item.split('_')
         return (

--- a/src/components/ecosystem/tabs/FeaturedApps.tsx
+++ b/src/components/ecosystem/tabs/FeaturedApps.tsx
@@ -23,7 +23,9 @@
  */
 
 import React, { useMemo } from 'react'
-import { Grid, Box } from '@mui/material'
+import { Link } from 'react-router-dom'
+import { Grid, Box, Button } from '@mui/material'
+import AddCircleOutlineRoundedIcon from '@mui/icons-material/AddCircleOutlineRounded'
 import { cls, cmn, SkPaper } from '@skalenetwork/metaport'
 import AppCard from '../AppCardV2'
 import Carousel from '../../Carousel'
@@ -40,6 +42,8 @@ interface FeaturedAppsProps {
   newApps: types.AppWithChainAndName[]
   useCarousel?: boolean
   gray?: boolean
+  showSeeMoreButton?: boolean
+  schainName?: string
 }
 
 const FeaturedApps: React.FC<FeaturedAppsProps> = ({
@@ -49,7 +53,9 @@ const FeaturedApps: React.FC<FeaturedAppsProps> = ({
   newApps,
   trendingApps,
   useCarousel = false,
-  gray = true
+  gray = true,
+  showSeeMoreButton = false,
+  schainName
 }) => {
   const { getMostLikedApps, getAppId, getMostLikedRank } = useLikedApps()
   const trendingAppIds = useMemo(() => getMostLikedApps(), [getMostLikedApps])
@@ -101,9 +107,24 @@ const FeaturedApps: React.FC<FeaturedAppsProps> = ({
     <Grid container spacing={2}>
       {filteredFeaturedApps.map((app) => (
         <Grid key={`${app.chain}-${app.appName}`} item xs={12} sm={6} md={4} lg={4}>
-          <Box className={cls('fl-centered dappCard')}>{renderAppCard(app)}</Box>
-        </Grid>
+          <Box className={cls('fl-centered dappCard')}>{renderAppCard(app)}</Box> 
+        </Grid> 
       ))}
+      {showSeeMoreButton && (
+        <div className={cls(cmn.flex, cmn.mtop20)} style={{ justifyContent: 'center', width: '100%' }}>
+          <Link to={schainName ? `/ecosystem?chains=${schainName}` : "/ecosystem"}>
+            <Button
+              size="medium"
+              color="secondary"
+              variant="contained"
+              className={cls('btn', cmn.mtop20, 'secondary', 'seeMoreButton')}
+              startIcon={<AddCircleOutlineRoundedIcon />}
+            >
+              See more
+            </Button>
+          </Link>
+        </div>
+      )}
     </Grid>
   )
 }

--- a/src/core/ecosystem/apps.ts
+++ b/src/core/ecosystem/apps.ts
@@ -77,6 +77,15 @@ export function filterAppsBySearchTerm(
   return sortAndFilterApps(filteredApps)
 }
 
+export function filterAppsByChains(
+  apps: types.AppWithChainAndName[],
+  chains: string[]
+): types.AppWithChainAndName[] {
+  if (chains.length === 0) return sortAndFilterApps(apps)
+  const filteredApps = apps.filter((app) => chains.includes(app.chain))
+  return sortAndFilterApps(filteredApps)
+}
+
 export function getAppMeta(
   chainsMeta: types.ChainsMetadataMap,
   chain: string,

--- a/src/core/ecosystem/urlParamsUtil.ts
+++ b/src/core/ecosystem/urlParamsUtil.ts
@@ -57,10 +57,29 @@ export const useUrlParams = () => {
     [searchParams, setSearchParams]
   )
 
+  const getChainsFromUrl = useCallback(() => {
+    const chains = searchParams.get('chains')
+    return chains ? chains.split(',') : []
+  }, [searchParams])
+
+  const setChainsInUrl = useCallback(
+    (chains: string[]) => {
+      if (chains.length > 0) {
+        searchParams.set('chains', chains.join(','))
+      } else {
+        searchParams.delete('chains')
+      }
+      setSearchParams(searchParams)
+    },
+    [searchParams, setSearchParams]
+  )
+
   return {
     getCheckedItemsFromUrl,
     setCheckedItemsInUrl,
     getTabIndexFromUrl,
-    setTabIndexInUrl
+    setTabIndexInUrl,
+    getChainsFromUrl,
+    setChainsInUrl
   }
 }

--- a/src/pages/Ecosystem.tsx
+++ b/src/pages/Ecosystem.tsx
@@ -34,7 +34,7 @@ import AddCircleOutlineRoundedIcon from '@mui/icons-material/AddCircleOutlineRou
 import { type types } from '@/core'
 import { cmn, cls, type MetaportCore } from '@skalenetwork/metaport'
 import { META_TAGS } from '../core/meta'
-import { filterAppsByCategory, filterAppsBySearchTerm } from '../core/ecosystem/apps'
+import { filterAppsByCategory, filterAppsBySearchTerm, filterAppsByChains } from '../core/ecosystem/apps'
 import { useUrlParams } from '../core/ecosystem/urlParamsUtil'
 import { SKALE_SOCIAL_LINKS, SUBMIT_PROJECT_URL } from '../core/constants'
 import { useApps } from '../useApps'
@@ -60,7 +60,7 @@ export default function Ecosystem(props: {
   loadData: () => Promise<void>
 }) {
   const [searchParams] = useSearchParams()
-  const { getCheckedItemsFromUrl, setCheckedItemsInUrl, getTabIndexFromUrl, setTabIndexInUrl } =
+  const { getCheckedItemsFromUrl, setCheckedItemsInUrl, getTabIndexFromUrl, setTabIndexInUrl, getChainsFromUrl, setChainsInUrl } =
     useUrlParams()
   const { allApps, newApps, trendingApps, favoriteApps, isSignedIn, featuredApps } = useApps(
     props.chainsMeta,
@@ -68,6 +68,7 @@ export default function Ecosystem(props: {
   )
 
   const [checkedItems, setCheckedItems] = useState<string[]>([])
+  const [selectedChains, setSelectedChains] = useState<string[]>([])
   const [filteredApps, setFilteredApps] = useState<types.AppWithChainAndName[]>([])
   const [searchTerm, setSearchTerm] = useState('')
   const [activeTab, setActiveTab] = useState(0)
@@ -77,6 +78,8 @@ export default function Ecosystem(props: {
     props.loadData()
     const initialCheckedItems = getCheckedItemsFromUrl()
     setCheckedItems(initialCheckedItems)
+    const initialChains = getChainsFromUrl()
+    setSelectedChains(initialChains)
     const initialTabIndex = getTabIndexFromUrl()
     setActiveTab(initialTabIndex)
   }, [])
@@ -88,16 +91,24 @@ export default function Ecosystem(props: {
   
   useEffect(() => {
     const filtered = filterAppsBySearchTerm(
-      filterAppsByCategory(allApps, checkedItems),
+      filterAppsByChains(
+        filterAppsByCategory(allApps, checkedItems),
+        selectedChains
+      ),
       searchTerm,
       props.chainsMeta
     )
     setFilteredApps(filtered)
     setLoaded(true)
-  }, [allApps, checkedItems, searchTerm, props.chainsMeta])
+  }, [allApps, checkedItems, selectedChains, searchTerm, props.chainsMeta])
   const handleSetCheckedItems = (newCheckedItems: string[]) => {
     setCheckedItems(newCheckedItems)
     setCheckedItemsInUrl(newCheckedItems)
+  }
+
+  const handleSetSelectedChains = (newSelectedChains: string[]) => {
+    setSelectedChains(newSelectedChains)
+    setChainsInUrl(newSelectedChains)
   }
   const handleTabChange = (_: React.SyntheticEvent, newValue: number) => {
     setActiveTab(newValue)
@@ -149,7 +160,7 @@ export default function Ecosystem(props: {
 
   const currentFilteredApps = getFilteredAppsByTab(activeTab)
 
-  const isFiltersApplied = Object.keys(checkedItems).length !== 0
+  const isFiltersApplied = checkedItems.length !== 0 || selectedChains.length !== 0
   return (
     <>
       <Container maxWidth="md">
@@ -190,6 +201,9 @@ export default function Ecosystem(props: {
             <SelectedCategories
               checkedItems={checkedItems}
               setCheckedItems={handleSetCheckedItems}
+              selectedChains={selectedChains}
+              setSelectedChains={handleSetSelectedChains}
+              chainsMeta={props.chainsMeta}
               filteredAppsCount={currentFilteredApps.length}
             />
             <Tabs


### PR DESCRIPTION
To avoid overwhelming the Hub page, a “More” button was added at the end of the featured dApps list in this PR. When clicked, it displays only the dApps from the selected chain, following the same logic used in the categories section.
If the user clicks the close icon, it resets and shows all dApps again.
