### PR TITLE
Setup: Legacy network #613 for Hoodi instead of Holesky

### DIFF
--- a/config/legacy/europa.ts
+++ b/config/legacy/europa.ts
@@ -17,13 +17,13 @@ const connections: types.mp.TokenTypeMap = {
     },
     erc20: {
       skl: {
-        address: '0xcB5C15235A1FFdb5e7CBBfFa6F28c42BCC998271',
+        address: '0x7518a20B166614cD10b74be4833998875F1c8c5f',
         chains: {
           mainnet: {
             clone: true
           },
           'peaceful-outlying-ankaa': {
-            wrapper: '0x39e633E57e8334730c665e641751AE08FE2d7b76'
+            wrapper: '0x039E133b96E4A6A4Df7be7BF6157D558793f4f06'
           }
         }
       }

--- a/config/legacy/europa.ts
+++ b/config/legacy/europa.ts
@@ -9,21 +9,21 @@ const connections: types.mp.TokenTypeMap = {
           mainnet: {
             clone: true
           },
-          'adorable-quaint-bellatrix': {
-            wrapper: '0x3a830008c24300Dd8F469EBFEd13E4854409440D'
+          'peaceful-outlying-ankaa': {
+            wrapper: '0x9eCc5D8ceb51b95c9565D526114c11F03c122266'
           }
         }
       }
     },
     erc20: {
       skl: {
-        address: '0xDeCcD09457Bd23c4CDD3C6E07a00053Ff54869dd',
+        address: '0xcB5C15235A1FFdb5e7CBBfFa6F28c42BCC998271',
         chains: {
           mainnet: {
             clone: true
           },
-          'adorable-quaint-bellatrix': {
-            wrapper: '0xEc656cc30205479C5DAa3aDac7b4D9d0fe0FDc51'
+          'peaceful-outlying-ankaa': {
+            wrapper: '0x39e633E57e8334730c665e641751AE08FE2d7b76'
           }
         }
       }

--- a/config/legacy/index.ts
+++ b/config/legacy/index.ts
@@ -7,11 +7,11 @@ export const METAPORT_CONFIG: types.mp.Config = {
   openOnLoad: true,
   openButton: true,
   debug: false,
-  mainnetEndpoint: 'https://ethereum-holesky-rpc.publicnode.com',
+  mainnetEndpoint: 'https://ethereum-hoodi-rpc.publicnode.com',
   chains: [
     'mainnet',
-    'these-long-sadalsuud', // europa
-    'adorable-quaint-bellatrix' // nebula
+    'international-villainous-zaurak', // europa
+    'peaceful-outlying-ankaa' // nebula
   ],
   tokens: {
     eth: {
@@ -24,26 +24,26 @@ export const METAPORT_CONFIG: types.mp.Config = {
     }
   },
   connections: {
-    'these-long-sadalsuud': europaConnections,
-    'adorable-quaint-bellatrix': nebulaConnections,
+    'international-villainous-zaurak': europaConnections,
+    'peaceful-outlying-ankaa': nebulaConnections,
     mainnet: {
       eth: {
         eth: {
           chains: {
-            'these-long-sadalsuud': {},
-            'adorable-quaint-bellatrix': {
-              hub: 'these-long-sadalsuud'
+            'international-villainous-zaurak': {},
+            'peaceful-outlying-ankaa': {
+              hub: 'international-villainous-zaurak'
             }
           }
         }
       },
       erc20: {
         skl: {
-          address: '0x0E53fDa415cc6b2a7D9495D4a1F0659F0Ee45e0d',
+          address: '0xd54237fC00bd58fCd1d5648CfEDc38212dD185Af',
           chains: {
-            'these-long-sadalsuud': {},
-            'adorable-quaint-bellatrix': {
-              hub: 'these-long-sadalsuud'
+            'international-villainous-zaurak': {},
+            'peaceful-outlying-ankaa': {
+              hub: 'international-villainous-zaurak'
             }
           }
         }

--- a/config/legacy/index.ts
+++ b/config/legacy/index.ts
@@ -39,7 +39,7 @@ export const METAPORT_CONFIG: types.mp.Config = {
       },
       erc20: {
         skl: {
-          address: '0xd54237fC00bd58fCd1d5648CfEDc38212dD185Af',
+          address: '0x912a122fE382F0c531B622ff2A25dDc77bA25DE9',
           chains: {
             'international-villainous-zaurak': {},
             'peaceful-outlying-ankaa': {

--- a/config/legacy/nebula.ts
+++ b/config/legacy/nebula.ts
@@ -18,7 +18,7 @@ const connections: types.mp.TokenTypeMap = {
     },
     erc20: {
         skl: {
-        address: '0xC11Ba472327Bc1A235c67c12035D7e1B5A7AA9a3',
+        address: '0x1526881e947748Fac747d8fBf5820467A144b2a6',
         chains: {
             'international-villainous-zaurak': {
             clone: true

--- a/config/legacy/nebula.ts
+++ b/config/legacy/nebula.ts
@@ -4,27 +4,27 @@ const connections: types.mp.TokenTypeMap = {
     // Nebula connections
     eth: {
         eth: {
-        address: '0x9C0e8bC2B2D403299214c80081F93fAB5e10b593',
+        address: '0x3903eD11A48F5022A148904d9626ACFe78D812C1',
         chains: {
-            'these-long-sadalsuud': {
+            'international-villainous-zaurak': {
             clone: true
             },
             mainnet: {
             clone: true,
-            hub: 'these-long-sadalsuud'
+            hub: 'international-villainous-zaurak'
             }
         }
         }
     },
     erc20: {
         skl: {
-        address: '0xFbbDF9aC97093b1E88aB79F7D0c296d9cc5eD0d0',
+        address: '0xC11Ba472327Bc1A235c67c12035D7e1B5A7AA9a3',
         chains: {
-            'these-long-sadalsuud': {
+            'international-villainous-zaurak': {
             clone: true
             },
             mainnet: {
-            hub: 'these-long-sadalsuud',
+            hub: 'international-villainous-zaurak',
             clone: true
             }
         }

--- a/packages/core/src/contracts.ts
+++ b/packages/core/src/contracts.ts
@@ -56,9 +56,9 @@ export const PREDEPLOYED_ALIAS = 'predeployed'
 export const CONTRACTS: ContractsConfig = {
   mainnet: {},
   legacy: {
-    'skale-manager': '0x27C393Cd6CBD071E5F5F2227a915d3fF3650aeaE',
-    'mainnet-ima': '0x0F38cD94a864329A67e4dc74F34153d048098e6F',
-    'skale-allocator': '0xCEabf2b0c4F9d75A49a7B1E3e3c3179cDe949C9F',
+    'skale-manager': '0x3E51d380a5A652bAecDE4BBAC62325f7C506dD4C',
+    'mainnet-ima': '0x518b7661F6Ef6170a5AB99eecC545621B81D054b',
+    'skale-allocator': '0x3F7f59Dc97689092c1EE7E0982646b3f92ed407a',
     'skale-grants': '0x3982411D90792aCDaCBa37b1fE2f23E4A3E97429'
   },
   regression: {},
@@ -80,8 +80,8 @@ export const PAYMASTER_CONTRACTS = {
     address: '0x9E444978d11E7e753017ce3329B01663D5D78240'
   },
   legacy: {
-    chain: 'adorable-quaint-bellatrix',
-    address: '0xb76A448071Ed77d22cAa1669567B5D28f5448d99'
+    chain: 'international-villainous-zaurak',
+    address: ' 0x9891d98E976dC8c6a65a26208Ab17718434dA1c5'
   },
   regression: {
     chain: '',

--- a/packages/core/src/contracts.ts
+++ b/packages/core/src/contracts.ts
@@ -59,7 +59,7 @@ export const CONTRACTS: ContractsConfig = {
     'skale-manager': '0x3E51d380a5A652bAecDE4BBAC62325f7C506dD4C',
     'mainnet-ima': '0x518b7661F6Ef6170a5AB99eecC545621B81D054b',
     'skale-allocator': '0x9dC47fce435e32779E03AD3dD24015479b9286D9',
-    'skale-grants': '0x3982411D90792aCDaCBa37b1fE2f23E4A3E97429'
+    'skale-grants': '0x1Bf7D9BAFd93945b02441B5f1C161C0dD5f439B3'
   },
   regression: {},
   testnet: {
@@ -81,7 +81,7 @@ export const PAYMASTER_CONTRACTS = {
   },
   legacy: {
     chain: 'international-villainous-zaurak',
-    address: ' 0x9891d98E976dC8c6a65a26208Ab17718434dA1c5'
+    address: '0x9891d98E976dC8c6a65a26208Ab17718434dA1c5'
   },
   regression: {
     chain: '',

--- a/packages/core/src/contracts.ts
+++ b/packages/core/src/contracts.ts
@@ -58,7 +58,7 @@ export const CONTRACTS: ContractsConfig = {
   legacy: {
     'skale-manager': '0x3E51d380a5A652bAecDE4BBAC62325f7C506dD4C',
     'mainnet-ima': '0x518b7661F6Ef6170a5AB99eecC545621B81D054b',
-    'skale-allocator': '0x3F7f59Dc97689092c1EE7E0982646b3f92ed407a',
+    'skale-allocator': '0x9dC47fce435e32779E03AD3dD24015479b9286D9',
     'skale-grants': '0x3982411D90792aCDaCBa37b1fE2f23E4A3E97429'
   },
   regression: {},

--- a/packages/core/src/endpoints.ts
+++ b/packages/core/src/endpoints.ts
@@ -33,7 +33,7 @@ const PROTOCOL: { [protocol in 'http' | 'ws']: string } = {
 
 export const MAINNET_EXPLORER_URLS: EndpointsNetworkMap = {
   mainnet: 'https://etherscan.io',
-  legacy: 'https://holesky.etherscan.io',
+  legacy: 'https://hoodi.etherscan.io',
   regression: 'https://goerli.etherscan.io',
   testnet: 'https://hoodi.etherscan.io'
 }

--- a/packages/core/src/metadata/faucet.json
+++ b/packages/core/src/metadata/faucet.json
@@ -31,7 +31,7 @@
       "func": "0x0c11dedd"
     },
     "international-villainous-zaurak": {
-      "address": " 0x6fe3168F757Dc4efdd95887401cA5E99448c0405",
+      "address": "0x6fe3168F757Dc4efdd95887401cA5E99448c0405",
       "func": "0x0c11dedd"
     }
   },

--- a/packages/core/src/metadata/faucet.json
+++ b/packages/core/src/metadata/faucet.json
@@ -26,16 +26,12 @@
     }
   },
   "legacy": {
-    "adorable-quaint-bellatrix": {
-      "address": "0x94977628d2EeDa78E2A56Abe178F432c46E13a6b",
+    "peaceful-outlying-ankaa": {
+      "address": "0xedc124a7e472bAc1940a256E4950e3Aa3F6D18d3",
       "func": "0x0c11dedd"
     },
-    "these-long-sadalsuud": {
-      "address": "0xb45FA2D56C9f82d130Eb007a76F1FB3631d99b3b",
-      "func": "0x0c11dedd"
-    },
-    "spanish-smug-auva": {
-      "address": "0xa101902B3119f4830292bb79ebAB56967229207B",
+    "international-villainous-zaurak": {
+      "address": " 0x6fe3168F757Dc4efdd95887401cA5E99448c0405",
       "func": "0x0c11dedd"
     }
   },

--- a/packages/metaport/src/core/network.ts
+++ b/packages/metaport/src/core/network.ts
@@ -34,7 +34,7 @@ import { TimeoutException } from './exceptions'
 const log = new Logger<ILogObj>({ name: 'metaport:core:network' })
 
 export const CHAIN_IDS: { [network in types.SkaleNetwork]: number } = {
-  legacy: 17000,
+  legacy: 560048,
   regression: 5,
   mainnet: 1,
   testnet: 560048


### PR DESCRIPTION
In this pull request, Karina, Vadim, and I configured the new Legacy network (#613) for Hoodi, replacing Holesky.
We added the new chains in all relevant places and updated the contract addresses accordingly.
We also added the Allocator and Paymaster contracts.