### PR TITLE
Fixed the bug  "Settings Filtering by category cuts off the top row of dApps" - #624

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:packages": "bun run --cwd packages/core build && bun run --cwd packages/metaport build",
     "build:mainnet": "bun run build:packages && NETWORK_NAME=mainnet bash scripts/build.sh",
     "build:testnet": "bun run build:packages && NETWORK_NAME=testnet bash scripts/build.sh",
+    "build:qa": "bun run build:packages && NETWORK_NAME=legacy bash scripts/build.sh",
     "dev": "bun run build:packages && vite",
     "dev:portal": "vite",
     "dev:watch": "bunx concurrently -k -n CORE,METAPORT,PORTAL -c cyan,magenta,green 'bun run --cwd packages/core dev' 'bun run --cwd packages/metaport dev' 'bun run dev:portal'",

--- a/src/pages/Ecosystem.tsx
+++ b/src/pages/Ecosystem.tsx
@@ -109,7 +109,7 @@ export default function Ecosystem(props: {
       window.removeEventListener('resize', handleResize)
       window.removeEventListener('scroll', handleScroll)
     }
-  }, [])
+  }, [checkedItems])
 
   useEffect(() => {
     props.loadData()


### PR DESCRIPTION
In this PR, we fixed the following issue (#624):
After applying a category filter, the top row of dApps was partially cut off from view. The newly added filter tag pushed the content grid down, making the top results not fully visible even when the page was scrolled to the top.

Now, after applying a filter, the layout no longer shifts. The checked items logic was added to the handleScroll function so the top row of dApps always remains fully visible after the results are updated.

We also added the build:qa script to the package.json file to allow checking the QA network during the development stage in the future.

