### PR TITLE
Fixed favorites gird #626 

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:packages": "bun run --cwd packages/core build && bun run --cwd packages/metaport build",
     "build:mainnet": "bun run build:packages && NETWORK_NAME=mainnet bash scripts/build.sh",
     "build:testnet": "bun run build:packages && NETWORK_NAME=testnet bash scripts/build.sh",
+    "build:qa": "bun run build:packages && NETWORK_NAME=legacy bash scripts/build.sh",
     "dev": "bun run build:packages && vite",
     "dev:portal": "vite",
     "dev:watch": "bunx concurrently -k -n CORE,METAPORT,PORTAL -c cyan,magenta,green 'bun run --cwd packages/core dev' 'bun run --cwd packages/metaport dev' 'bun run dev:portal'",

--- a/src/components/ecosystem/tabs/FavoriteApps.tsx
+++ b/src/components/ecosystem/tabs/FavoriteApps.tsx
@@ -25,7 +25,8 @@ import { useMemo } from 'react'
 import { types } from '@/core'
 import { useLikedApps } from '../../../LikedAppsContext'
 import AppCard from '../AppCardV2'
-import { Button, Grid } from '@mui/material'
+import Button from '@mui/material/Button'
+import { Grid } from '@mui/material'
 import GridViewRoundedIcon from '@mui/icons-material/GridViewRounded'
 import { cls, cmn, SkPaper } from '@skalenetwork/metaport'
 import Carousel from '../../Carousel'
@@ -57,15 +58,7 @@ export default function FavoriteApps(props: {
     const isFeaturedApps = isFeatured({ chain: app.chain, app: app.appName }, props.featuredApps)
 
     return (
-      <Grid
-        key={`${app.appName}-${app.chain}`}
-        className={cls('fl-centered dappCard')}
-        item
-        lg={4}
-        md={4}
-        sm={6}
-        xs={12}
-      >
+      <Grid key={`${app.appName}-${app.chain}`} size={{ xs: 12, sm: 6, md: 4, lg: 4 }}>
         <AppCard
           key={`${app.chain}-${app.appName}`}
           schainName={app.chain}

--- a/src/pages/Ecosystem.tsx
+++ b/src/pages/Ecosystem.tsx
@@ -109,7 +109,7 @@ export default function Ecosystem(props: {
       window.removeEventListener('resize', handleResize)
       window.removeEventListener('scroll', handleScroll)
     }
-  }, [])
+  }, [checkedItems])
 
   useEffect(() => {
     props.loadData()


### PR DESCRIPTION
In this PR, we fixed the Favorites tab layout #626 

On the Favorites tab, the project cards were stretched and displayed in a single long column instead of being arranged in neat rows, meaning the grid wasn’t working correctly. We fixed this by applying the same grid layout used on the other tabs.