### PR TITLE
Version name changed to 4.2.0 - #632

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "portal",
   "private": true,
-  "version": "4.1.0",
+  "version": "4.2.0",
   "type": "module",
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
This PR fixes the version inconsistency introduced in the previous 4.2.0 PRs by updating the version number in the package .json file:
- Changed 4.1.0 to 4.2.0 to match the current release for QA to be able to test it with the new version. #632 