### PR TITLE
Portal 4.2 - Develop to Beta

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -414,6 +414,10 @@ body {
     font-size: 1.2rem;
   }
 
+  @media (max-width: 600px) {
+    bottom: calc(50px + 1rem);
+    right: 1rem;
+  }
 }
 
 .btn {

--- a/src/pages/Ecosystem.tsx
+++ b/src/pages/Ecosystem.tsx
@@ -83,6 +83,11 @@ export default function Ecosystem(props: {
   const [headerHeight, setHeaderHeight] = useState(0)
 
   useLayoutEffect(() => {
+    if (props.isXs) {
+      setHeaderHeight(0)
+      return
+    }
+
     const syncPosition = () => {
       if (!containerRef.current || !fixedHeaderRef.current) return
       const rect = containerRef.current.getBoundingClientRect()
@@ -109,7 +114,7 @@ export default function Ecosystem(props: {
       window.removeEventListener('resize', handleResize)
       window.removeEventListener('scroll', handleScroll)
     }
-  }, [checkedItems])
+  }, [checkedItems, props.isXs])
 
   useEffect(() => {
     props.loadData()
@@ -208,15 +213,18 @@ export default function Ecosystem(props: {
             ref={fixedHeaderRef}
             className="sk-header"
             style={{
-              position: 'fixed',
-              top: '101px',
+              position: props.isXs ? 'static' : 'fixed',
+              top: props.isXs ? 'auto' : '101px',
               background: 'black',
               borderRadius: '35px',
-              zIndex: 1000,
+              zIndex: props.isXs ? 'undefined' : 1000,
               width: '100%'
             }}
           >
-            <Container maxWidth="md">
+            <Container 
+              maxWidth="md"
+              sx={props.isXs ? { paddingLeft: 0, paddingRight: 0 } : {}}
+            >
               <SkStack>
                 <div className={cls(cmn.flexg, cmn.mbott20, cmn.mtop10)}>
                   <h2 className={cls(cmn.nom)}>Ecosystem</h2>
@@ -231,7 +239,7 @@ export default function Ecosystem(props: {
                   </div>
                 </div>
               </SkStack>
-              <SkStack className={cls(cmn.mbott20, cmn.flex, cmn.flexcv)}>
+              <SkStack className={cls(cmn.mbott20, cmn.flex, cmn.flexcv, [cmn.mtop10, props.isXs])}>
                 <SearchComponent
                   className={cls(cmn.flexg, [cmn.mri10, !props.isXs], ['fullW', props.isXs])}
                   searchTerm={searchTerm}
@@ -288,7 +296,7 @@ export default function Ecosystem(props: {
               </Tabs>
             </Container>
           </div>
-          <div style={{ height: headerHeight }} />
+          {!props.isXs && <div style={{ height: headerHeight }} />}
           <Box sx={{ flexGrow: 1 }} className={cls(cmn.mtop20, 'fwmobile')}>
             {activeTab === 0 && (
               <AllApps


### PR DESCRIPTION
This PR removes the sticky ecosystem header on mobile devices for now, as it was taking up too much space.

It also adjusts the “Scroll to Top” button on mobile to improve alignment with the other UI elements.