### PR TITLE
Remove ntest token

### DIFF
--- a/config/base-sepolia-testnet/index.ts
+++ b/config/base-sepolia-testnet/index.ts
@@ -41,12 +41,6 @@ export const METAPORT_CONFIG: types.mp.Config = {
       name: 'Wrapped Ether',
       iconUrl: 'https://assets.coingecko.com/coins/images/2518/standard/weth.png?1696503332'
     },
-    ntest: {
-      decimals: 18,
-      symbol: 'NTEST',
-      name: 'Native Test Token',
-      iconUrl: 'https://s2.coinmarketcap.com/static/img/coins/64x64/1027.png'
-    },
     axiosusd: {
       decimals: 6,
       symbol: 'AxiosUSD',
@@ -91,12 +85,6 @@ export const METAPORT_CONFIG: types.mp.Config = {
         },
         weth: {
           address: '0x4200000000000000000000000000000000000006',
-          chains: {
-            'jubilant-horrible-ancha': {}
-          }
-        },
-        ntest: {
-          address: '0x366727B410fE55774C8b0B5b5A6E2d74199a088A',
           chains: {
             'jubilant-horrible-ancha': {}
           }
@@ -149,14 +137,6 @@ export const METAPORT_CONFIG: types.mp.Config = {
         },
         usdc: {
           address: '0x2e08028E3C4c2356572E096d8EF835cD5C6030bD',
-          chains: {
-            mainnet: {
-              clone: true
-            }
-          }
-        },
-        ntest: {
-          address: '0xbEbe120F44F2F0E35841DE45a044885bB933f1e2',
           chains: {
             mainnet: {
               clone: true

--- a/config/base/index.ts
+++ b/config/base/index.ts
@@ -41,12 +41,6 @@ export const METAPORT_CONFIG: types.mp.Config = {
       name: 'Wrapped Ether',
       iconUrl: 'https://assets.coingecko.com/coins/images/2518/standard/weth.png?1696503332'
     },
-    ntest: {
-      decimals: 18,
-      symbol: 'NTEST',
-      name: 'Native Test Token',
-      iconUrl: 'https://s2.coinmarketcap.com/static/img/coins/64x64/1027.png'
-    },
     axiosusd: {
       decimals: 6,
       symbol: 'AxiosUSD',


### PR DESCRIPTION
This pull request removes the configuration for the `NTEST` (Native Test Token) from both the `base` and `base-sepolia-testnet` environment config files. The removal affects both the token metadata and its network-specific addresses.

Token configuration cleanup:

* Removed the `ntest` token metadata (including decimals, symbol, name, and icon URL) from `config/base/index.ts` and `config/base-sepolia-testnet/index.ts`. [[1]](diffhunk://#diff-dd9999714efa6b879d782ee398ff6b7204cfaa1cb8921563ef0d3a65631c6442L44-L49) [[2]](diffhunk://#diff-fa0894e8d77e9a823672ca2a0f2aca8409f87db42d5f1fada9f2dc0f9e0190f3L44-L49)

Network address configuration cleanup:

* Removed the `ntest` token addresses and chain mapping from the `mainnet` and `jubilant-horrible-ancha` chain sections in `config/base-sepolia-testnet/index.ts`. [[1]](diffhunk://#diff-fa0894e8d77e9a823672ca2a0f2aca8409f87db42d5f1fada9f2dc0f9e0190f3L98-L103) [[2]](diffhunk://#diff-fa0894e8d77e9a823672ca2a0f2aca8409f87db42d5f1fada9f2dc0f9e0190f3L158-L165)