### PR TITLE
Add variable ETH reserve amount per network, add new SKL L2 testnet token

### DIFF
--- a/config/base-sepolia-testnet/index.ts
+++ b/config/base-sepolia-testnet/index.ts
@@ -60,9 +60,9 @@ export const METAPORT_CONFIG: types.mp.Config = {
       },
       erc20: {
         skl: {
-          address: '0xC20874EB2D51e4e61bBC07a4E7CA1358F449A2cF',
+          address: '0xBeBb7CA7D7FFB39ad2d87C51c742E29B3C12C2b2',
           chains: {
-            'jubilant-horrible-ancha': {}
+            // 'jubilant-horrible-ancha': {}
           }
         },
         usdc: {
@@ -127,14 +127,14 @@ export const METAPORT_CONFIG: types.mp.Config = {
             }
           }
         },
-        skl: {
-          address: '0xaf2e0ff5b5f51553fdb34ce7f04a6c3201cee57b',
-          chains: {
-            mainnet: {
-              clone: true
-            }
-          }
-        },
+        // skl: {
+        //   address: '0xaf2e0ff5b5f51553fdb34ce7f04a6c3201cee57b',
+        //   chains: {
+        //     mainnet: {
+        //       clone: true
+        //     }
+        //   }
+        // },
         usdc: {
           address: '0x2e08028E3C4c2356572E096d8EF835cD5C6030bD',
           chains: {

--- a/packages/metaport/src/components/AmountInput.tsx
+++ b/packages/metaport/src/components/AmountInput.tsx
@@ -28,7 +28,7 @@ import { dc, units } from '@/core'
 import TextField from '@mui/material/TextField'
 import { Button } from '@mui/material'
 
-import { SFUEL_RESERVE_AMOUNT } from '../core/constants'
+import { ETH_RESERVE_AMOUNT } from '../core/constants'
 
 import TokenList from './TokenList'
 import { useMetaportStore } from '../store/MetaportStore'
@@ -47,6 +47,7 @@ export default function AmountInput() {
 
   const tokenBalances = useMetaportStore((state) => state.tokenBalances)
   const token = useMetaportStore((state) => state.token)
+  const mpc = useMetaportStore((state) => state.mpc)
 
   const maxAmount = tokenBalances[token?.keyname]
 
@@ -68,7 +69,10 @@ export default function AmountInput() {
   const setMaxAmount = () => {
     let maxAmountWei: bigint = maxAmount
     if (token.type === dc.TokenType.eth) {
-      const reserveAmountEth = units.toWei(SFUEL_RESERVE_AMOUNT.toString(), token.meta.decimals)
+      const reserveAmountEth = units.toWei(
+        ETH_RESERVE_AMOUNT[mpc.config.skaleNetwork].toString(),
+        token.meta.decimals
+      )
       maxAmountWei = maxAmount - reserveAmountEth
     }
     const balanceEther = units.formatBalance(maxAmountWei, token.meta.decimals)

--- a/packages/metaport/src/core/actions/checks.ts
+++ b/packages/metaport/src/core/actions/checks.ts
@@ -25,7 +25,7 @@ import { Logger, type ILogObj } from 'tslog'
 import { Contract } from 'ethers'
 import { dc, type types, units, helper } from '@/core'
 
-import { SFUEL_RESERVE_AMOUNT } from '../constants'
+import { ETH_RESERVE_AMOUNT } from '../constants'
 import { MainnetChain, SChain } from '../contracts'
 
 const log = new Logger<ILogObj>({ name: 'metaport:core:actions:checks' })
@@ -34,7 +34,8 @@ export async function checkEthBalance( // TODO: optimize balance checks
   chain: MainnetChain | SChain,
   address: string,
   amount: string,
-  tokenData: dc.TokenData
+  tokenData: dc.TokenData,
+  skaleNetwork: types.SkaleNetwork
 ): Promise<types.mp.CheckRes> {
   const checkRes: types.mp.CheckRes = { res: false }
   if (!amount || Number(amount) === 0) return checkRes
@@ -55,8 +56,9 @@ export async function checkEthBalance( // TODO: optimize balance checks
     let checkedAmount = Number(amount)
     let msg = `Current balance: ${balanceEther} ${tokenData.meta.symbol}.`
     if (chain instanceof MainnetChain) {
-      checkedAmount += SFUEL_RESERVE_AMOUNT
-      msg += ` ${SFUEL_RESERVE_AMOUNT} ETH will be reserved to cover transfer costs.`
+      const reserveAmount = ETH_RESERVE_AMOUNT[skaleNetwork]
+      checkedAmount += reserveAmount
+      msg += ` ${reserveAmount} ETH will be reserved to cover transfer costs.`
     }
     if (checkedAmount > balanceEther) {
       checkRes.msg = msg

--- a/packages/metaport/src/core/actions/eth.ts
+++ b/packages/metaport/src/core/actions/eth.ts
@@ -57,7 +57,8 @@ export class TransferEthM2S extends Action {
       this.mainnet,
       this.address,
       this.amount,
-      this.token
+      this.token,
+      this.mpc.config.skaleNetwork
     )
     if (!checkResBalance.res) {
       this.setAmountErrorMessage(checkResBalance.msg)
@@ -97,7 +98,8 @@ export class TransferEthS2M extends Action {
       this.sChain1,
       this.address,
       this.amount,
-      this.token
+      this.token,
+      this.mpc.config.skaleNetwork
     )
     if (!checkResBalance.res) {
       this.setAmountErrorMessage(checkResBalance.msg)

--- a/packages/metaport/src/core/constants.ts
+++ b/packages/metaport/src/core/constants.ts
@@ -21,6 +21,8 @@
  * @copyright SKALE Labs 2022-Present
  */
 
+import { type types } from '@/core'
+
 export const M2S_POSTFIX = 'm2s'
 export const S2M_POSTFIX = 's2m'
 export const S2S_POSTFIX = 's2s'
@@ -61,6 +63,13 @@ export const _BALANCE_UPDATE_INTERVAL_SECONDS = 10
 export const BALANCE_UPDATE_INTERVAL_MS = _BALANCE_UPDATE_INTERVAL_SECONDS * 1000
 export const COMMUNITY_POOL_DECIMALS = 6
 
-export const SFUEL_RESERVE_AMOUNT = 0.0001
+export const ETH_RESERVE_AMOUNT: { [key in types.SkaleNetwork]: number } = {
+  mainnet: 0.0005,
+  legacy: 0.0001,
+  regression: 0.0001,
+  testnet: 0.0001,
+  'base-sepolia-testnet': 0.000005,
+  base: 0.000005
+}
 
 export const SUCCESS_EMOJIS = ['🎉', '👌', '✅', '🙌', '🎊']

--- a/src/components/CopySurface.tsx
+++ b/src/components/CopySurface.tsx
@@ -28,8 +28,6 @@ import { TokenIcon } from '@skalenetwork/metaport'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import Tooltip from '@mui/material/Tooltip'
 import ButtonBase from '@mui/material/ButtonBase'
-import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded'
-import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import { CircleCheck, Copy } from 'lucide-react'
 
 export default function CopySurface(props: {
@@ -77,7 +75,7 @@ export default function CopySurface(props: {
                   </div>
                 ) : null}
                 {props.icon && <div className="mr-1.5 text-secondary-foreground">{props.icon}</div>}
-                <p className="text-xs text-secondary-foreground">
+                <p className="text-xs text-secondary-foreground truncate">
                   {props.title}
                   {props.tokenMetadata
                     ? ` (${props.tokenMetadata.decimals ?? constants.DEFAULT_ERC20_DECIMALS})`

--- a/src/components/chains/tabs/Tokens.tsx
+++ b/src/components/chains/tabs/Tokens.tsx
@@ -56,15 +56,15 @@ export default function Tokens(props: {
         </div>,
         ...(wrapperAddress
           ? [
-              <div key={`w${tokenSymbol}`} className="col-span-1">
-                <CopySurface
-                  className="h-full"
-                  title={`w${tokenSymbol.toUpperCase()}`}
-                  value={getAddress(wrapperAddress)}
-                  tokenMetadata={props.mpc.config.tokens[tokenSymbol]}
-                />
-              </div>
-            ]
+            <div key={`w${tokenSymbol}`} className="col-span-1">
+              <CopySurface
+                className="h-full"
+                title={`w${tokenSymbol.toUpperCase()}`}
+                value={getAddress(wrapperAddress)}
+                tokenMetadata={props.mpc.config.tokens[tokenSymbol]}
+              />
+            </div>
+          ]
           : [])
       ]
     })


### PR DESCRIPTION
This pull request introduces several important updates to the Metaport configuration and codebase, primarily focusing on improving how ETH reserve amounts are handled for different SKALE networks and cleaning up token configurations. The most significant changes include replacing the static `SFUEL_RESERVE_AMOUNT` with a network-specific `ETH_RESERVE_AMOUNT`, updating function signatures and usages accordingly, and modifying the configuration to comment out or update certain SKL token entries.

**ETH Reserve Handling Improvements:**

* Replaced the static `SFUEL_RESERVE_AMOUNT` constant with a new `ETH_RESERVE_AMOUNT` object that specifies reserve amounts per `SkaleNetwork` in `constants.ts`, and updated all relevant imports and usages to reference this new object. [[1]](diffhunk://#diff-0a3d2b3800423480bd8abe68da973818ef92002d37baee2cfd7cb4b8b02e3bdaL64-R73) [[2]](diffhunk://#diff-969c157140a54675cb31d0cf6c6b7a30ee96d3d89e6f6d424c92c82c7aa3fe70L31-R31) [[3]](diffhunk://#diff-037107744354f5762c9f85f8071cc08c0a938bb312a8015bfe1b442234142095L28-R28)
* Updated functions such as `checkEthBalance` and related method calls to accept the `skaleNetwork` parameter and use the appropriate reserve amount for the current network, ensuring accurate balance checks and error messages. [[1]](diffhunk://#diff-037107744354f5762c9f85f8071cc08c0a938bb312a8015bfe1b442234142095L37-R38) [[2]](diffhunk://#diff-037107744354f5762c9f85f8071cc08c0a938bb312a8015bfe1b442234142095L58-R61) [[3]](diffhunk://#diff-c2b70974f2fda9be0d90b3b098366c1abc625a14ad115210d53499e3dd534ab3L60-R61) [[4]](diffhunk://#diff-c2b70974f2fda9be0d90b3b098366c1abc625a14ad115210d53499e3dd534ab3L100-R102) [[5]](diffhunk://#diff-969c157140a54675cb31d0cf6c6b7a30ee96d3d89e6f6d424c92c82c7aa3fe70L71-R75) [[6]](diffhunk://#diff-969c157140a54675cb31d0cf6c6b7a30ee96d3d89e6f6d424c92c82c7aa3fe70R50)

**Metaport Configuration Updates:**

* Updated the `skl` token address in the `erc20` section and commented out the `jubilant-horrible-ancha` chain entry in the `base-sepolia-testnet` config.
* Commented out the `skl` token entry in another section of the `base-sepolia-testnet` config to disable it.

**UI/UX Improvements:**

* Improved the `CopySurface` component by truncating long titles for better display and removed unused icon imports. [[1]](diffhunk://#diff-221b9ab530606142ad16182cfd2290afd0389f1c7e62c6a92005ec57edb1e71bL31-L32) [[2]](diffhunk://#diff-221b9ab530606142ad16182cfd2290afd0389f1c7e62c6a92005ec57edb1e71bL80-R78)

**Other:**

* Minor import adjustments to ensure type safety and maintainability in `constants.ts`.