### PR TITLE
Update legacy addresses and sсhain names

### DIFF
--- a/config/legacy/europa.ts
+++ b/config/legacy/europa.ts
@@ -9,21 +9,21 @@ const connections: types.mp.TokenTypeMap = {
           mainnet: {
             clone: true
           },
-          'young-coarse-celaeno': {
-            wrapper: '0xC3E554E49f0Ad593Cbdb7552B98a755f87EB0987'
+          'overcooked-profuse-gienah-cygni': {
+            wrapper: '0x4576157B8fc0Ea0a51E9606f578d3ed221764040'
           }
         }
       }
     },
     erc20: {
       skl: {
-        address: '0xd0A604054e5322344eeA2A77E5d71c1167670d0f',
+        address: '0x423C6ffDe8a83787B48B22Db4d3283386085390b',
         chains: {
           mainnet: {
             clone: true
           },
-          'young-coarse-celaeno': {
-            wrapper: '0xd9271785E81f640CF1C9F6C43BF69607CECd1986'
+          'overcooked-profuse-gienah-cygni': {
+            wrapper: '0xDD62FCbB11D660Ce49782660D22174D491be6E90'
           }
         }
       }

--- a/config/legacy/index.ts
+++ b/config/legacy/index.ts
@@ -10,8 +10,8 @@ export const METAPORT_CONFIG: types.mp.Config = {
   mainnetEndpoint: 'https://ethereum-hoodi-rpc.publicnode.com',
   chains: [
     'mainnet',
-    'honored-impish-wezen', // europa
-    'young-coarse-celaeno' // nebula
+    'talkative-victorious-rasalgethi', // europa
+    'overcooked-profuse-gienah-cygni' // nebula
   ],
   tokens: {
     eth: {
@@ -24,15 +24,15 @@ export const METAPORT_CONFIG: types.mp.Config = {
     }
   },
   connections: {
-    'honored-impish-wezen': europaConnections,
-    'young-coarse-celaeno': nebulaConnections,
+    'talkative-victorious-rasalgethi': europaConnections,
+    'overcooked-profuse-gienah-cygni': nebulaConnections,
     mainnet: {
       eth: {
         eth: {
           chains: {
-            'honored-impish-wezen': {},
-            'young-coarse-celaeno': {
-              hub: 'honored-impish-wezen'
+            'talkative-victorious-rasalgethi': {},
+            'overcooked-profuse-gienah-cygni': {
+              hub: 'talkative-victorious-rasalgethi'
             }
           }
         }
@@ -41,9 +41,9 @@ export const METAPORT_CONFIG: types.mp.Config = {
         skl: {
           address: '0x912a122fE382F0c531B622ff2A25dDc77bA25DE9',
           chains: {
-            'honored-impish-wezen': {},
-            'young-coarse-celaeno': {
-              hub: 'honored-impish-wezen'
+            'talkative-victorious-rasalgethi': {},
+            'overcooked-profuse-gienah-cygni': {
+              hub: 'talkative-victorious-rasalgethi'
             }
           }
         }

--- a/config/legacy/nebula.ts
+++ b/config/legacy/nebula.ts
@@ -4,27 +4,27 @@ const connections: types.mp.TokenTypeMap = {
     // Nebula connections
     eth: {
         eth: {
-        address: '0xa2b496C018ea6cE6f44bA4366d9970CFfec89D6e',
+        address: '0x19faa73826fBd204Cb8323ef5a7f78EB9C838f97',
         chains: {
-            'honored-impish-wezen': {
+            'talkative-victorious-rasalgethi': {
             clone: true
             },
             mainnet: {
             clone: true,
-            hub: 'honored-impish-wezen'
+            hub: 'talkative-victorious-rasalgethi'
             }
         }
         }
     },
     erc20: {
         skl: {
-        address: '0x9EcD93c2cF9E551B3B02939c72D3F515A8cb76B0',
+        address: '0xb33ED61afDD4e378ECE6dF97AaA41F8E207f43cA',
         chains: {
-            'honored-impish-wezen': {
+            'talkative-victorious-rasalgethi': {
             clone: true
             },
             mainnet: {
-            hub: 'honored-impish-wezen',
+            hub: 'talkative-victorious-rasalgethi',
             clone: true
             }
         }

--- a/packages/core/src/contracts.ts
+++ b/packages/core/src/contracts.ts
@@ -105,8 +105,8 @@ export const PAYMASTER_CONTRACTS = {
     address: '0x9E444978d11E7e753017ce3329B01663D5D78240'
   },
   legacy: {
-    chain: 'honored-impish-wezen',
-    address: '0xd9FA9a9A68D7A5C518Ad1FE5A75ed892Cd1765db'
+    chain: 'talkative-victorious-rasalgethi',
+    address: '0x57d9d64121dCC66Cda45813357A8276400b83dd1'
   },
   regression: {
     chain: '',

--- a/packages/core/src/metadata/faucet.json
+++ b/packages/core/src/metadata/faucet.json
@@ -26,12 +26,12 @@
     }
   },
   "legacy": {
-    "young-coarse-celaeno": {
-      "address": "0xbf49aaFA1Cb7EF2933a1BBA70e84393f61B01244",
+    "overcooked-profuse-gienah-cygni": {
+      "address": "0x7f772D57BfC903605F3925e92F18De4BdA70A7ED",
       "func": "0x0c11dedd"
     },
-    "honored-impish-wezen": {
-      "address": "0xabD19274cE3F0A9834b155831d4aAC2d1360681a",
+    "talkative-victorious-rasalgethi": {
+      "address": "0x53c6122426aCa77B06DB7Aee69C0c6381029D32D",
       "func": "0x0c11dedd"
     }
   },


### PR DESCRIPTION
Updated Legacy network with new schain names and contract addresses:

- Europa (`talkative-victorious-rasalgethi`): wETH, SKL, wSKL, sFUEL faucet addresses
- Nebula (`overcooked-profuse-gienah-cygni`): ETH, SKL, sFUEL faucet addresses
- Paymaster contract address