### PR TITLE
Fix Portal 5.0: Enable Disabled State on Retrieve Modal

### DIFF
--- a/src/components/delegation/Reward.tsx
+++ b/src/components/delegation/Reward.tsx
@@ -157,7 +157,7 @@ export default function Reward(props: {
                   <>
                     <RetrieveRewardModal
                       address={props.address}
-                      //  disabled={retrieveDisabled}
+                      disabled={retrieveDisabled}
                       customRewardAddress={props.customRewardAddress}
                       setCustomRewardAddress={props.setCustomRewardAddress}
                       retrieveRewards={retrieveRewards}


### PR DESCRIPTION
This pull request makes a minor update to the `Reward` component. It enables the `disabled` prop on the `RetrieveRewardModal` by uncommenting it, which will allow the modal to be properly disabled when `retrieveDisabled` is true.