### PR TITLE
Fix disabled button states to align with UI

### DIFF
--- a/packages/metaport/src/components/AddToken.tsx
+++ b/packages/metaport/src/components/AddToken.tsx
@@ -109,7 +109,7 @@ export default function AddToken(props: {
       disabled={loading}
       color="primary"
       size="medium"
-      className="grow mb-2! md:mb-0! w-full! md:w-fit! md:mr-3! capitalize! text-accent! bg-foreground! disabled:bg-foreground/30! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
+      className="grow mb-2! md:mb-0! w-full! md:w-fit! md:mr-3! capitalize! text-accent! bg-foreground! disabled:bg-muted-foreground/30! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
       startIcon={<Coins size={17} />}
     >
       {loading ? 'Check wallet' : 'Add token'}

--- a/packages/metaport/src/components/Stepper/SkStepper.tsx
+++ b/packages/metaport/src/components/Stepper/SkStepper.tsx
@@ -215,7 +215,7 @@ export default function SkStepper(props: { skaleNetwork: types.SkaleNetwork }) {
                   onClick={startOver}
                   color="primary"
                   size="medium"
-                  className="grow w-full! md:w-fit! capitalize! text-accent! bg-foreground! disabled:bg-foreground/30! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
+                  className="grow w-full! md:w-fit! capitalize! text-accent! bg-foreground! disabled:bg-muted-foreground/30! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
                   startIcon={<RotateCcw size={17} />}
                 >
                   Start over

--- a/src/components/SchainDetails.tsx
+++ b/src/components/SchainDetails.tsx
@@ -187,7 +187,7 @@ export default function SchainDetails(props: {
           <a target="_blank" rel="noreferrer" href={explorerUrl} className="undec w-full md:w-auto">
             <Button
               size="medium"
-              className="w-full! md:w-fit! md:mr-3! capitalize! text-accent! bg-foreground! disabled:bg-foreground/30! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
+              className="w-full! md:w-fit! md:mr-3! capitalize! text-accent! bg-foreground! disabled:bg-muted-foreground/30! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
               startIcon={<Blocks size={17} />}
             >
               Block Explorer
@@ -201,7 +201,7 @@ export default function SchainDetails(props: {
                 <CirclePlus size={17} />
               )
             }
-            className="w-full! md:w-fit! md:mr-3! capitalize! text-accent! bg-foreground! disabled:bg-foreground/30! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
+            className="w-full! md:w-fit! md:mr-3! capitalize! text-accent! bg-foreground! disabled:bg-muted-foreground/30! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
             onClick={addNetwork}
             disabled={loading}
           >
@@ -217,7 +217,7 @@ export default function SchainDetails(props: {
             >
               <Button
                 size="medium"
-                className="w-full! md:w-fit! md:mr-3! capitalize! text-accent! bg-foreground! disabled:bg-foreground/30! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
+                className="w-full! md:w-fit! md:mr-3! capitalize! text-accent! bg-foreground! disabled:bg-muted-foreground/30! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
                 startIcon={<ExternalLink size={17} className="textd-green-600" />}
               >
                 Open Website


### PR DESCRIPTION
This pull request updates the styling for disabled buttons across multiple components, making the disabled background color lighter for improved visual clarity and consistency. All affected buttons now use `disabled:bg-foreground/30!` instead of `disabled:bg-foreground/50!`.

Button style updates for disabled state:

* [`AddToken.tsx`](diffhunk://#diff-c4a6c360017e8474e772971ee3941141df9feaec52b38d001adc216ea3d662f5L112-R112): Changed disabled button background color to `disabled:bg-foreground/30!` for the "Add token" button.
* [`SkStepper.tsx`](diffhunk://#diff-fdb06ed9a44b9ea4ad01713b42e525afa3eb6c1ac15d340362226dcd742c848bL218-R218): Updated disabled background color to `disabled:bg-foreground/30!` for the "Start over" button.
* [`SchainDetails.tsx`](diffhunk://#diff-dfde8d97337d7704a8b1e89c20b5e5e23a77e51106a5c235c5452dcca1496c75L190-R190): Changed disabled background color to `disabled:bg-foreground/30!` for the "Block Explorer", "Add Network", and "Open Website" buttons. [[1]](diffhunk://#diff-dfde8d97337d7704a8b1e89c20b5e5e23a77e51106a5c235c5452dcca1496c75L190-R190) [[2]](diffhunk://#diff-dfde8d97337d7704a8b1e89c20b5e5e23a77e51106a5c235c5452dcca1496c75L204-R204) [[3]](diffhunk://#diff-dfde8d97337d7704a8b1e89c20b5e5e23a77e51106a5c235c5452dcca1496c75L220-R220)