### PR TITLE
Added texted muted for muted foreground buttons

### DIFF
--- a/packages/metaport/src/components/AddToken.tsx
+++ b/packages/metaport/src/components/AddToken.tsx
@@ -109,7 +109,7 @@ export default function AddToken(props: {
       disabled={loading}
       color="primary"
       size="medium"
-      className="grow mb-2! md:mb-0! w-full! md:w-fit! md:mr-3! capitalize! text-accent! bg-foreground! disabled:bg-muted-foreground/30! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
+      className="grow mb-2! md:mb-0! w-full! md:w-fit! md:mr-3! capitalize! text-accent! bg-foreground! disabled:bg-muted-foreground/30! disabled:text-muted! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
       startIcon={<Coins size={17} />}
     >
       {loading ? 'Check wallet' : 'Add token'}

--- a/packages/metaport/src/components/CommunityPool.tsx
+++ b/packages/metaport/src/components/CommunityPool.tsx
@@ -286,7 +286,7 @@ export default function CommunityPool() {
             <div>
               <Button
                 variant="contained"
-                className=" w-full mt-5! btnMd normal-case! text-sm font-semibold text-accent! bg-foreground! disabled:bg-muted-foreground/30! disabled:text-muted-foreground! py-3.5 px-4 rounded shadow-none"
+                className=" w-full mt-5! btnMd normal-case! text-sm font-semibold text-accent! bg-foreground! disabled:bg-muted-foreground/30! disabled:text-muted! py-3.5 px-4 rounded shadow-none"
                 onClick={rechargeCP}
                 disabled={
                   !!loading ||

--- a/packages/metaport/src/components/Stepper/SkStepper.tsx
+++ b/packages/metaport/src/components/Stepper/SkStepper.tsx
@@ -215,7 +215,7 @@ export default function SkStepper(props: { skaleNetwork: types.SkaleNetwork }) {
                   onClick={startOver}
                   color="primary"
                   size="medium"
-                  className="grow w-full! md:w-fit! capitalize! text-accent! bg-foreground! disabled:bg-muted-foreground/30! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
+                  className="grow w-full! md:w-fit! capitalize! text-accent! bg-foreground! disabled:bg-muted-foreground/30! disabled:text-muted! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
                   startIcon={<RotateCcw size={17} />}
                 >
                   Start over

--- a/src/components/SchainDetails.tsx
+++ b/src/components/SchainDetails.tsx
@@ -187,7 +187,7 @@ export default function SchainDetails(props: {
           <a target="_blank" rel="noreferrer" href={explorerUrl} className="undec w-full md:w-auto">
             <Button
               size="medium"
-              className="w-full! md:w-fit! md:mr-3! capitalize! text-accent! bg-foreground! disabled:bg-muted-foreground/30! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
+              className="w-full! md:w-fit! md:mr-3! capitalize! text-accent! bg-foreground! disabled:bg-muted-foreground/30! disabled:text-muted! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
               startIcon={<Blocks size={17} />}
             >
               Block Explorer
@@ -201,7 +201,7 @@ export default function SchainDetails(props: {
                 <CirclePlus size={17} />
               )
             }
-            className="w-full! md:w-fit! md:mr-3! capitalize! text-accent! bg-foreground! disabled:bg-muted-foreground/30! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
+            className="w-full! md:w-fit! md:mr-3! capitalize! text-accent! bg-foreground! disabled:bg-muted-foreground/30! disabled:text-muted! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
             onClick={addNetwork}
             disabled={loading}
           >
@@ -217,7 +217,7 @@ export default function SchainDetails(props: {
             >
               <Button
                 size="medium"
-                className="w-full! md:w-fit! md:mr-3! capitalize! text-accent! bg-foreground! disabled:bg-muted-foreground/30! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
+                className="w-full! md:w-fit! md:mr-3! capitalize! text-accent! bg-foreground! disabled:bg-muted-foreground/30! disabled:text-muted! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
                 startIcon={<ExternalLink size={17} className="textd-green-600" />}
               >
                 Open Website

--- a/src/components/credits/ChainCreditsTile.tsx
+++ b/src/components/credits/ChainCreditsTile.tsx
@@ -257,7 +257,7 @@ const ChainCreditsTile: React.FC<ChainCreditsTileProps> = ({
                   size="small"
                   variant="contained"
                   startIcon={<CirclePlus size={14} />}
-                  className="btnMd ml-5 bg-accent-foreground! disabled:bg-muted-foreground/30! text-accent! ease-in-out transition-transform duration-150 active:scale-[0.97]"
+                  className="btnMd ml-5 bg-accent-foreground! disabled:bg-muted-foreground/30! disabled:text-muted! text-accent! ease-in-out transition-transform duration-150 active:scale-[0.97]"
                   onClick={() => setOpenModal(true)}
                   disabled={creditStation === undefined}
                 >
@@ -395,7 +395,7 @@ const ChainCreditsTile: React.FC<ChainCreditsTileProps> = ({
           </div>
           <Button
             variant="contained"
-            className="btn mt-4! p-4! w-full capitalize! bg-accent-foreground! disabled:bg-muted-foreground/30! text-accent!"
+            className="btn mt-4! p-4! w-full capitalize! bg-accent-foreground! disabled:bg-muted-foreground/30! disabled:text-muted! text-accent!"
             startIcon={<CoinsIcon size={17} />}
             size="large"
             onClick={buyCredits}

--- a/src/components/credits/TokenAdminTile.tsx
+++ b/src/components/credits/TokenAdminTile.tsx
@@ -240,7 +240,7 @@ const TokenAdminTile: React.FC<TokenAdminTileProps> = ({
           </SkPaper>
           <Button
             variant="contained"
-            className="btnMd ml-5 w-full mt-4! mb-2! bg-accent-foreground! disabled:bg-muted-foreground/30! text-accent! ease-in-out transition-transform duration-150 active:scale-[0.97]"
+            className="btnMd ml-5 w-full mt-4! mb-2! bg-accent-foreground! disabled:bg-muted-foreground/30! disabled:text-muted! text-accent! ease-in-out transition-transform duration-150 active:scale-[0.97]"
             size="large"
             onClick={updatePrice}
             disabled={loading || price === ''}


### PR DESCRIPTION
This pull request makes a consistent UI improvement across several components by ensuring that disabled buttons also apply the `text-muted` style, making their appearance clearer and more accessible to users. The change adds the `disabled:text-muted!` class to button elements when they are disabled.

**UI consistency and accessibility improvements:**

* Added the `disabled:text-muted!` class to the `className` of all relevant `Button` components in the following files, ensuring that disabled buttons display muted text for better clarity and consistency:
  - `AddToken.tsx`
  - `CommunityPool.tsx`
  - `SkStepper.tsx`
  - `SchainDetails.tsx` [[1]](diffhunk://#diff-dfde8d97337d7704a8b1e89c20b5e5e23a77e51106a5c235c5452dcca1496c75L190-R190) [[2]](diffhunk://#diff-dfde8d97337d7704a8b1e89c20b5e5e23a77e51106a5c235c5452dcca1496c75L204-R204) [[3]](diffhunk://#diff-dfde8d97337d7704a8b1e89c20b5e5e23a77e51106a5c235c5452dcca1496c75L220-R220)
  - `ChainCreditsTile.tsx` [[1]](diffhunk://#diff-a362966732073615542c48b878bd96ca2e12fd2f8d9b563731d6b5fedad60376L260-R260) [[2]](diffhunk://#diff-a362966732073615542c48b878bd96ca2e12fd2f8d9b563731d6b5fedad60376L398-R398)
  - `TokenAdminTile.tsx`