### PR TITLE
Get s-fuel button added on the chain details page

### DIFF
--- a/src/components/GetSFuel.tsx
+++ b/src/components/GetSFuel.tsx
@@ -21,13 +21,107 @@
  * @copyright SKALE Labs 2024-Present
  */
 
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { Box, Button, Tooltip } from '@mui/material'
 import AutoModeRoundedIcon from '@mui/icons-material/AutoModeRounded'
-import { type MetaportCore, useWagmiAccount } from '@skalenetwork/metaport'
+import { type MetaportCore, Station, useWagmiAccount, useConnectModal } from '@skalenetwork/metaport'
+import { type types } from '@/core'
 import { usesFuel } from '../useSFuel'
 import { Zap } from 'lucide-react'
 
-export default function GetSFuel({ mpc }: { mpc: MetaportCore }) {
+function SingleChainSFuel({ chainName, mpc }: { chainName: string; mpc: MetaportCore }) {
+  const { address } = useWagmiAccount()
+  const { openConnectModal } = useConnectModal()
+
+  const [sFuelOk, setSFuelOk] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [mining, setMining] = useState(false)
+  const pendingMine = useRef(false)
+
+  const faucetAvailable = new Station(chainName, mpc).isFaucetAvailable()
+
+  const doMine = useCallback(async (addr: types.AddressType) => {
+    const station = new Station(chainName, mpc)
+    setMining(true)
+    try {
+      const { ok: mined } = await station.doPoW(addr)
+      if (!mined) return
+      await new Promise((r) => setTimeout(r, 3000))
+      setLoading(true)
+      const { ok } = await station.getData(addr)
+      setSFuelOk(ok ?? false)
+    } finally {
+      setLoading(false)
+      setMining(false)
+    }
+  }, [chainName, mpc])
+
+  const checkBalance = useCallback(async () => {
+    if (!address) return
+    setLoading(true)
+    try {
+      const { ok } = await new Station(chainName, mpc).getData(address)
+      setSFuelOk(ok ?? false)
+      if (pendingMine.current && !(ok ?? false)) {
+        pendingMine.current = false
+        await doMine(address)
+      } else {
+        pendingMine.current = false
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [address, chainName, mpc, doMine])
+
+  useEffect(() => {
+    if (!address) {
+      setSFuelOk(false)
+      setLoading(false)
+      return
+    }
+    checkBalance()
+  }, [address, checkBalance])
+
+  async function handleClick() {
+    if (!address) {
+      pendingMine.current = true
+      openConnectModal?.()
+      return
+    }
+    if (sFuelOk) return
+    await doMine(address)
+  }
+
+  function btnText() {
+    if (!address) return 'Get sFUEL'
+    if (mining) return 'Getting sFUEL'
+    if (loading) return 'Checking sFUEL'
+    return sFuelOk ? 'sFUEL OK' : 'Get sFUEL'
+  }
+
+  if (!faucetAvailable) return null
+
+  return (
+    <Button
+      startIcon={
+        sFuelOk && address ? (
+          <Zap size={17} className="text-green-300 dark:text-green-600" />
+        ) : (
+          <Zap size={17} />
+        )
+      }
+      className="w-full! md:w-fit! md:mr-3! capitalize! text-accent! bg-foreground! disabled:bg-muted-foreground/30! disabled:text-muted! text-xs! px-6! py-4! ease-in-out transition-transform duration-150 active:scale-[0.97]"
+      onClick={handleClick}
+      disabled={mining || loading}
+    >
+      {btnText()}
+    </Button>
+  )
+}
+
+export default function GetSFuel({ mpc, chainName }: { mpc: MetaportCore; chainName?: string }) {
+  if (chainName) return <SingleChainSFuel chainName={chainName} mpc={mpc} />
+
   const { sFuelOk, isMining, mineSFuel, sFuelCompletionPercentage, loading } = usesFuel(mpc)
   const { address } = useWagmiAccount()
   if (!address) return null

--- a/src/components/SchainDetails.tsx
+++ b/src/components/SchainDetails.tsx
@@ -51,6 +51,7 @@ import {
   TrendingUp,
   Users
 } from 'lucide-react'
+import GetSFuel from './GetSFuel'
 
 export default function SchainDetails(props: {
   chainsMeta: types.ChainsMetadataMap
@@ -207,6 +208,8 @@ export default function SchainDetails(props: {
           >
             {connectBtnText()}
           </Button>
+          
+          <GetSFuel mpc={props.mpc} chainName={props.chain.name} />
 
           {chainMeta?.url && (
             <a


### PR DESCRIPTION
This pull request introduces a new `SingleChainSFuel` component to streamline the process of obtaining sFUEL for a specific chain and integrates it into the `SchainDetails` view. The changes enhance user experience by providing a dedicated button to check sFUEL status and trigger mining actions for individual chains, with improved state handling and UI feedback.

**sFUEL acquisition improvements:**

* Added the `SingleChainSFuel` component in `GetSFuel.tsx` to handle sFUEL mining and status checks for a single chain, including UI state management and faucet availability checks.
* Updated the main `GetSFuel` component to delegate to `SingleChainSFuel` when a `chainName` is provided, enabling per-chain sFUEL handling.

**Integration with chain details UI:**

* Imported and integrated the new `GetSFuel` component into `SchainDetails.tsx`, displaying the sFUEL button within the chain details view for the selected chain. [[1]](diffhunk://#diff-dfde8d97337d7704a8b1e89c20b5e5e23a77e51106a5c235c5452dcca1496c75R54) [[2]](diffhunk://#diff-dfde8d97337d7704a8b1e89c20b5e5e23a77e51106a5c235c5452dcca1496c75R212-R213)