### PR TITLE
Comment out Get Started button (broken link for now)

### DIFF
--- a/src/SkDrawer.tsx
+++ b/src/SkDrawer.tsx
@@ -87,7 +87,7 @@ export default function SkDrawer(props: { validatorDelegations: types.st.IDelega
                 </ListItemButton>
               </Link>
             </ListItem>
-            <ListItem>
+            {/* <ListItem>
               <a
                 className="w-full text-foreground!"
                 target="_blank"
@@ -101,7 +101,7 @@ export default function SkDrawer(props: { validatorDelegations: types.st.IDelega
                   <ListItemText primary="Get Started" />
                 </ListItemButton>
               </a>
-            </ListItem>
+            </ListItem> */}
           </List>
           <h4 className="text-secondary-foreground text-xs font-medium mt-2.5 ml-5">Transfer</h4>
           <List>


### PR DESCRIPTION
This pull request makes a minor change to the `src/SkDrawer.tsx` file by commenting out a list item that contained a "Get Started" link. This effectively removes the "Get Started" option from the drawer UI without deleting the code, making it easy to restore later if needed. [[1]](diffhunk://#diff-26d806e0997269518d94febb38d2c4229f498d6fae61096fc4a69e51fd2fa2f1L90-R90) [[2]](diffhunk://#diff-26d806e0997269518d94febb38d2c4229f498d6fae61096fc4a69e51fd2fa2f1L104-R104)