### PR TITLE
Improve Mobile UX: Add Mobile Menu Items, Update Network Visibility, and Refine Responsive Layout

### DIFF
--- a/src/components/HelpZen.tsx
+++ b/src/components/HelpZen.tsx
@@ -36,7 +36,7 @@ export default function HelpZen() {
   }, [])
 
   return (
-    <div>
+    <div className="hidden! md:block!">
       <Box sx={{ display: 'flex', alignItems: 'center', textAlign: 'center' }}>
         <IconButton
           size="small"

--- a/src/components/MoreMenu.tsx
+++ b/src/components/MoreMenu.tsx
@@ -27,6 +27,8 @@ import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import { useTheme } from '@mui/material/styles'
 
 import { Link } from 'react-router-dom'
 
@@ -37,10 +39,14 @@ import {
   ListOrdered,
   BookOpen,
   MessagesSquare,
-  ExternalLink
+  ExternalLink,
+  MessageCircle,
+  HelpCircle
 } from 'lucide-react'
 
 export default function MoreMenu() {
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const open = Boolean(anchorEl)
   const handleClick = (event: MouseEvent<HTMLElement>) => {
@@ -80,6 +86,29 @@ export default function MoreMenu() {
         transformOrigin={{ horizontal: 'right', vertical: 'top' }}
         anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
       >
+        {isMobile && (
+          <MenuItem
+            onClick={() => {
+              handleClose()
+              window.zE('messenger', 'open')
+            }}
+            className="flex items-center px-2.5! py-2! text-sm! font-sans! font-semibold! text-foreground! hover:bg-muted! rounded-lg!"
+          >
+            <MessageCircle className="mr-2.5 h-[17px] w-[17px] text-muted-foreground" />
+            Open support chat
+          </MenuItem>
+        )}
+        {isMobile && (
+          <Link to="/other/faq" className="undec">
+            <MenuItem
+              onClick={handleClose}
+              className="flex items-center px-2.5! py-2! text-sm! font-sans! font-semibold! text-foreground! hover:bg-muted! rounded-lg!"
+            >
+              <HelpCircle className="mr-2.5 h-[17px] w-[17px] text-muted-foreground" />
+              Bridge FAQ
+            </MenuItem>
+          </Link>
+        )}
         <Link to="/other/terms-of-service" className="undec">
           <MenuItem
             onClick={handleClose}

--- a/src/components/MoreMenu.tsx
+++ b/src/components/MoreMenu.tsx
@@ -27,8 +27,6 @@ import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
-import useMediaQuery from '@mui/material/useMediaQuery'
-import { useTheme } from '@mui/material/styles'
 
 import { Link } from 'react-router-dom'
 
@@ -45,8 +43,6 @@ import {
 } from 'lucide-react'
 
 export default function MoreMenu() {
-  const theme = useTheme()
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const open = Boolean(anchorEl)
   const handleClick = (event: MouseEvent<HTMLElement>) => {
@@ -86,7 +82,7 @@ export default function MoreMenu() {
         transformOrigin={{ horizontal: 'right', vertical: 'top' }}
         anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
       >
-        {isMobile && (
+        <div className="md:hidden">
           <MenuItem
             onClick={() => {
               handleClose()
@@ -97,8 +93,8 @@ export default function MoreMenu() {
             <MessageCircle className="mr-2.5 h-[17px] w-[17px] text-muted-foreground" />
             Open support chat
           </MenuItem>
-        )}
-        {isMobile && (
+        </div>
+        <div className="md:hidden">
           <Link to="/other/faq" className="undec">
             <MenuItem
               onClick={handleClose}
@@ -108,7 +104,7 @@ export default function MoreMenu() {
               Bridge FAQ
             </MenuItem>
           </Link>
-        )}
+        </div>
         <Link to="/other/terms-of-service" className="undec">
           <MenuItem
             onClick={handleClose}

--- a/src/components/NetworkSwitch.tsx
+++ b/src/components/NetworkSwitch.tsx
@@ -48,7 +48,7 @@ export default function NetworkSwitch(props: { mpc: MetaportCore }) {
   return (
     <div>
       <Box
-        sx={{ alignItems: 'center', textAlign: 'center', display: { xs: 'none', sm: 'flex' } }}
+        sx={{ alignItems: 'center', textAlign: 'center', display: 'flex' }}
         className="ml-1.5"
       >
         <Tooltip arrow title="Switch SKALE Network">
@@ -60,10 +60,12 @@ export default function NetworkSwitch(props: { mpc: MetaportCore }) {
               skaleNetwork={props.mpc.config.skaleNetwork}
               chainName={constants.MAINNET_CHAIN_NAME}
               size="xs"
-              className="mr-2.5"
+              className="sm:mr-2.5"
               chainsMeta={mp_metadata.CHAINS_META[props.mpc.config.skaleNetwork]}
             />
-            {props.mpc.config.skaleNetwork.replace(/-/g, ' ')}
+            <span className="max-md:hidden">
+              {props.mpc.config.skaleNetwork.replace(/-/g, ' ')}
+            </span>
           </Button>
         </Tooltip>
       </Box>


### PR DESCRIPTION
This pull request makes improvements to the responsiveness and user experience of the UI components, particularly for mobile devices. The main changes involve updating menus and layout visibility to better support mobile users, and refining the display of network information.

**Mobile experience enhancements:**

* Added mobile-specific menu items to `MoreMenu`, including "Open support chat" and "Bridge FAQ", which are only shown on mobile devices.
* Introduced responsive detection in `MoreMenu` by using `useMediaQuery` and `useTheme` to determine if the user is on a mobile device. [[1]](diffhunk://#diff-037e382ac34b7ee754dd010ae521a8f7d1c2d385e85c86bfe227568afb250625R30-R31) [[2]](diffhunk://#diff-037e382ac34b7ee754dd010ae521a8f7d1c2d385e85c86bfe227568afb250625L40-R49)

**Layout and visibility updates:**

* Changed the main container in `HelpZen` to only display on medium and larger screens, hiding it on mobile for improved layout.
* Updated the `NetworkSwitch` component to always use flex display, removing the previous breakpoint restriction for consistency across screen sizes.
* Modified the `NetworkSwitch` button to show the network name only on medium and larger screens, improving clarity and reducing clutter on mobile.