### PR TITLE
Skale netwrok statistics responsible on light and dark mode

### DIFF
--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -25,12 +25,15 @@ import { Helmet } from 'react-helmet'
 
 import Container from '@mui/material/Container'
 import Stack from '@mui/material/Stack'
+import { useThemeMode } from '@skalenetwork/metaport'
 
 import { DASHBOARD_URL } from '../core/constants'
 import { META_TAGS } from '../core/meta'
 import SkPageInfoIcon from '../components/SkPageInfoIcon'
 
 export default function Stats() {
+  const { mode } = useThemeMode()
+
   return (
     <Container maxWidth="lg">
       <Helmet>
@@ -56,7 +59,8 @@ export default function Stats() {
             border: 'none',
             margin: '-15px -15px',
             zIndex: '1',
-            borderRadius: '15px'
+            borderRadius: '15px',
+            filter: mode === 'light' ? 'invert(100%)' : 'none'
           }}
           src={DASHBOARD_URL}
         ></iframe>

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -25,14 +25,12 @@ import { Helmet } from 'react-helmet'
 
 import Container from '@mui/material/Container'
 import Stack from '@mui/material/Stack'
-import { useThemeMode } from '@skalenetwork/metaport'
 
 import { DASHBOARD_URL } from '../core/constants'
 import { META_TAGS } from '../core/meta'
 import SkPageInfoIcon from '../components/SkPageInfoIcon'
 
 export default function Stats() {
-  const { mode } = useThemeMode()
 
   return (
     <Container maxWidth="lg">
@@ -59,9 +57,9 @@ export default function Stats() {
             border: 'none',
             margin: '-15px -15px',
             zIndex: '1',
-            borderRadius: '15px',
-            filter: mode === 'light' ? 'invert(100%)' : 'none'
+            borderRadius: '15px'
           }}
+          className='invert-100 dark:invert-0'
           src={DASHBOARD_URL}
         ></iframe>
       </Stack>

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -31,7 +31,6 @@ import { META_TAGS } from '../core/meta'
 import SkPageInfoIcon from '../components/SkPageInfoIcon'
 
 export default function Stats() {
-
   return (
     <Container maxWidth="lg">
       <Helmet>


### PR DESCRIPTION
This pull request introduces a small enhancement to the `Stats` page by making the embedded dashboard visually adapt to the current theme mode. The main change is the application of a filter to invert the dashboard colors when the light mode is active, improving its appearance and consistency with the rest of the UI.

**Theme adaptation:**

* Added `useThemeMode` hook from `@skalenetwork/metaport` and applied a conditional CSS filter to the dashboard iframe so that it inverts colors in light mode, ensuring better visual integration with the page theme. [[1]](diffhunk://#diff-e8ee5a67143618991a245e5f5a0ea390b9114fdb8a7eedf25541f686e27951c4R28-R36) [[2]](diffhunk://#diff-e8ee5a67143618991a245e5f5a0ea390b9114fdb8a7eedf25541f686e27951c4L59-R63)