### PR TITLE
Show Recent Transaction History Inline in Bridge Modal

### DIFF
--- a/packages/metaport/src/components/History.tsx
+++ b/packages/metaport/src/components/History.tsx
@@ -29,7 +29,7 @@ import Chain from './Chain'
 
 import { useMetaportStore } from '../store/MetaportStore'
 import { MoveRight } from 'lucide-react'
-export default function History(props: { size?: types.Size }) {
+export default function History(props: { size?: types.Size; limit?: number }) {
   const transactionsHistory = useMetaportStore((state) => state.transactionsHistory)
   const transfersHistory = useMetaportStore((state) => state.transfersHistory)
 
@@ -39,6 +39,10 @@ export default function History(props: { size?: types.Size }) {
   const network = mpc.config.skaleNetwork
 
   if (transactionsHistory.length === 0 && transfersHistory.length === 0) return
+
+  const reversedTransfers = transfersHistory.slice().reverse()
+  const displayedTransfers = props.limit ? reversedTransfers.slice(0, props.limit) : reversedTransfers
+
   return (
     <div>
       {transactionsHistory.length !== 0 ? (
@@ -60,9 +64,7 @@ export default function History(props: { size?: types.Size }) {
         </div>
       ) : null}
       <div>
-        {transfersHistory
-          .slice()
-          .reverse()
+        {displayedTransfers
           .map((transfer: types.mp.TransferHistory, key: number) => (
             <div
               key={key}
@@ -80,25 +82,25 @@ export default function History(props: { size?: types.Size }) {
                     chainName={transfer.chainName1}
                     size='xs'
                     decIcon
-                    iconSize='sm'
+                    iconSize={size === 'sm' ? 'xs' : 'sm'}
                   />
-                  <MoveRight size={14}
-                    className={`text-foreground ml-2 mr-2 w-3 h-3`}
+                  <MoveRight size={size === 'sm' ? 12 : 14}
+                    className={`text-foreground ${size === 'sm' ? 'ml-1.5 mr-1.5 w-2.5 h-2.5' : 'ml-2 mr-2 w-3 h-3'}`}
                   />
                   <Chain
                     skaleNetwork={network}
                     chainName={transfer.chainName2}
-                    size='sm'
+                    size='xs'
                     decIcon
-                    iconSize='sm'
+                    iconSize={size === 'sm' ? 'xs' : 'sm'}
                   />
                 </div>
 
-                <div className="flex items-center ml-1.5 sm:mr-4">
+                <div className={`flex items-center ${size === 'sm' ? 'mr-2' : 'ml-1.5 sm:mr-4'}`}>
                   <div className="flex items-center">
                     <TokenIcon
                       tokenSymbol={transfer.tokenKeyname}
-                      size={size == 'sm' ? 'xs' : 'sm'}
+                      size='xs'
                     />
                   </div>
                   <p

--- a/src/pages/Bridge.tsx
+++ b/src/pages/Bridge.tsx
@@ -24,9 +24,14 @@
 import { Helmet } from 'react-helmet'
 import { useEffect, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
-import HistoryIcon from '@mui/icons-material/History'
 
-import { useMetaportStore, SkPaper, TransactionData, useWagmiAccount } from '@skalenetwork/metaport'
+import {
+  TransactionData,
+  SkPaper,
+  useMetaportStore,
+  History as TransfersHistory,
+  useWagmiAccount
+} from '@skalenetwork/metaport'
 import { type types, dc, networks } from '@/core'
 
 import Container from '@mui/material/Container'
@@ -38,7 +43,7 @@ import { META_TAGS } from '../core/meta'
 import Meson from '../components/Meson'
 import SkPageInfoIcon from '../components/SkPageInfoIcon'
 import { NETWORKS } from '../core/constants'
-import SkIconBtn from '../components/SkIconBth'
+import { Button } from '@mui/material'
 
 interface TokenParams {
   keyname: string | null
@@ -68,6 +73,7 @@ export default function Bridge(props: { chainsMeta: types.ChainsMetadataMap }) {
     tokens,
     setToken,
     transactionsHistory,
+    transfersHistory,
     addressChanged
   } = useMetaportStore((state) => state)
 
@@ -177,9 +183,6 @@ export default function Bridge(props: { chainsMeta: types.ChainsMetadataMap }) {
             )}
           </div>
           <div>
-            <Link to="/bridge/history">
-              <SkIconBtn primary icon={HistoryIcon} size="small" tooltipTitle="Bridge History" />
-            </Link>
             <SkPageInfoIcon meta_tag={META_TAGS.bridge} />
           </div>
         </div>
@@ -202,6 +205,22 @@ export default function Bridge(props: { chainsMeta: types.ChainsMetadataMap }) {
               </SkPaper>
             </div>
           ) : null}
+          {address && (
+            <>
+              <TransfersHistory size="sm" limit={2} />
+              {(transactionsHistory.length > 0 || transfersHistory.length > 0) && (
+                <div className="flex justify-center mt-2.5">
+                 <Button                   
+                   component={Link}
+                   to="/bridge/history"
+                   className="btnMd w-full! items-center text-secondary-foreground! outlined hover:bg-muted-foreground/30!"                 >
+                   View all history
+                 </Button>
+                </div>
+              )}
+        
+            </>
+          )}
         </div>
       </Stack>
       <Meson


### PR DESCRIPTION
This pull request enhances the bridge history UI by improving how recent transfer history is displayed and making the interface more compact and user-friendly. The main changes include adding a prop to limit the number of displayed history items, and updating the bridge page to show a concise summary of recent transfers with a clear call to view the full history.

**History display improvements:**

* Added a `limit` prop to the `History` component to allow displaying only a specified number of recent transfer entries. The displayed transfers are now reversed and sliced based on this limit. (`History.tsx`) [[1]](diffhunk://#diff-6ecace6d5747d48572223f364ef733ce9637e0796bb9d19e5633c71efd39c641L32-R32) [[2]](diffhunk://#diff-6ecace6d5747d48572223f364ef733ce9637e0796bb9d19e5633c71efd39c641R42-R45) [[3]](diffhunk://#diff-6ecace6d5747d48572223f364ef733ce9637e0796bb9d19e5633c71efd39c641L63-R67)


**Bridge page integration:**

* Updated the bridge page to import and use the `History` component as `TransfersHistory`, displaying only the two most recent transfers in a compact format when the user is connected. (`Bridge.tsx`) [[1]](diffhunk://#diff-24a84f59ca649ee999f9ba0efad6368cabd8e268ab0b67829aa06a334fcb7334L27-R34) [[2]](diffhunk://#diff-24a84f59ca649ee999f9ba0efad6368cabd8e268ab0b67829aa06a334fcb7334R76) [[3]](diffhunk://#diff-24a84f59ca649ee999f9ba0efad6368cabd8e268ab0b67829aa06a334fcb7334R208-R223)
* Replaced the previous icon button for viewing history with a more prominent "View all history" button, which appears only when there is history to show, improving discoverability and navigation. (`Bridge.tsx`) [[1]](diffhunk://#diff-24a84f59ca649ee999f9ba0efad6368cabd8e268ab0b67829aa06a334fcb7334L180-L182) [[2]](diffhunk://#diff-24a84f59ca649ee999f9ba0efad6368cabd8e268ab0b67829aa06a334fcb7334R208-R223)
* Minor code cleanup, such as removing unused imports and switching to MUI's `Button` component. (`Bridge.tsx`)