### PR TITLE
All chains always available with swap feature

### DIFF
--- a/packages/metaport/src/components/BridgeChainCard.tsx
+++ b/packages/metaport/src/components/BridgeChainCard.tsx
@@ -52,7 +52,6 @@ export default function BridgeChainCard(props: ChainCardProps) {
   const backgroundColor = getChainCardBackgroundColor(skaleNetwork, disabled, chainsMeta, chainName, mode)
   const firstSentence = extractFirstSentence(chainDescription)
 
-  const disabledText = props.from ? 'Destination chain' : 'Source chain'
 
   const theme = useTheme()
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'))
@@ -62,8 +61,7 @@ export default function BridgeChainCard(props: ChainCardProps) {
   return (
     <div onClick={disabled ? undefined : onClick} style={{ height: 287 }}>
       <SkPaper
-        gray={disabled}
-        className={`${'flex items-center justify-center mt-5'} ${!disabled ? 'cursor-pointer' : ''} ${disabled ? styles.disabledCard : ''} ${styles.fullHeight}`}
+        className={`${'flex items-center justify-center mt-5'} ${styles.fullHeight}`}
         background={backgroundColor}
       >
         <div
@@ -87,20 +85,7 @@ export default function BridgeChainCard(props: ChainCardProps) {
             {metadata.getAlias(skaleNetwork, chainsMeta, chainName, undefined, true)}
           </p>
 
-          {disabled && (
-            <div className="flex items-center mt-2.5 mb-5">
-              <div className="grow"></div>
-              <SkPaper gray className="p-0">
-                <p
-                  className="text-xs font-semibold text-gray-400 mt-1.5 mb-1.5 ml-2.5 mr-2.5 truncate"
-                >
-                  {disabledText}
-                </p>
-              </SkPaper>
-              <div className="grow"></div>
-            </div>
-          )}
-          {!disabled && <p className="text-foreground/70 font-medium p-2 text-xs text-center">{firstSentence}</p>}
+          <p className="text-foreground/70 font-medium p-2 text-xs text-center">{firstSentence}</p>
         </div>
       </SkPaper>
     </div>

--- a/packages/metaport/src/components/ChainsList.tsx
+++ b/packages/metaport/src/components/ChainsList.tsx
@@ -23,6 +23,7 @@ export default function ChainsList(props: {
   size?: 'sm' | 'md'
   destChains?: string[]
   balance: React.ReactNode | null
+  onSwap?: () => void
 }) {
   const [open, setOpen] = React.useState(false)
 
@@ -36,6 +37,10 @@ export default function ChainsList(props: {
 
   function handle(schainName: string) {
     handleClose()
+    if (schainName === props.disabledChain) {
+      props.onSwap?.()
+      return
+    }
     props.setChain(schainName)
   }
 
@@ -109,7 +114,7 @@ export default function ChainsList(props: {
                     chainName={name}
                     chainsMeta={CHAINS_META[props.config.skaleNetwork]}
                     onClick={() => handle(name)}
-                    disabled={name === props.disabledChain}
+                    disabled={name === props.disabledChain && !props.onSwap}
                     from={props.from}
                   />
                 </div>

--- a/packages/metaport/src/components/WidgetBody.tsx
+++ b/packages/metaport/src/components/WidgetBody.tsx
@@ -35,6 +35,7 @@ export function WidgetBody(props) {
   const chainName2 = useMetaportStore((state) => state.chainName2)
   const setChainName1 = useMetaportStore((state) => state.setChainName1)
   const setChainName2 = useMetaportStore((state) => state.setChainName2)
+  const swapChains = useMetaportStore((state) => state.swapChains)
 
   const mpc = useMetaportStore((state) => state.mpc)
   const tokens = useMetaportStore((state) => state.tokens)
@@ -103,6 +104,7 @@ export function WidgetBody(props) {
                 disabledChain={chainName2}
                 disabled={transferInProgress}
                 from={true}
+                onSwap={swapChains}
                 balance={
                   token ? (
                     <TokenBalance
@@ -139,6 +141,7 @@ export function WidgetBody(props) {
               setChain={setChainName2}
               disabledChain={chainName1}
               disabled={transferInProgress}
+              onSwap={swapChains}
               balance={<DestTokenBalance />}
             />
           </SkPaper>

--- a/packages/metaport/src/store/MetaportState.ts
+++ b/packages/metaport/src/store/MetaportState.ts
@@ -73,6 +73,7 @@ export interface MetaportState {
 
   setChainName1: (name: string, customToken?: dc.TokenData) => void
   setChainName2: (name: string, customToken?: dc.TokenData) => void
+  swapChains: () => Promise<void>
 
   addressChanged: () => void
 

--- a/packages/metaport/src/store/MetaportStore.ts
+++ b/packages/metaport/src/store/MetaportStore.ts
@@ -260,6 +260,11 @@ export const useMetaportStore = create<MetaportState>()((set, get) => ({
     set(result)
   },
 
+  swapChains: async () => {
+    const result = await get().mpc.chainChanged(get().chainName2, get().chainName1, get().token)
+    set(result)
+  },
+
   addressChanged: () => {
     if (get().currentStep !== 0) {
       get().setTransfersHistory([

--- a/src/components/BridgeBody.tsx
+++ b/src/components/BridgeBody.tsx
@@ -57,6 +57,7 @@ export default function BridgeBody(props: { chainsMeta: types.ChainsMetadataMap 
   const chainName2 = useMetaportStore((state) => state.chainName2)
   const setChainName1 = useMetaportStore((state) => state.setChainName1)
   const setChainName2 = useMetaportStore((state) => state.setChainName2)
+  const swapChains = useMetaportStore((state) => state.swapChains)
 
   const mpc = useMetaportStore((state) => state.mpc)
   const tokenBalances = useMetaportStore((state) => state.tokenBalances)
@@ -95,6 +96,7 @@ export default function BridgeBody(props: { chainsMeta: types.ChainsMetadataMap 
             disabled={transferInProgress}
             from={true}
             size="md"
+            onSwap={swapChains}
             balance={
               token ? (
                 <TokenBalance
@@ -125,6 +127,7 @@ export default function BridgeBody(props: { chainsMeta: types.ChainsMetadataMap 
             disabledChain={chainName1}
             disabled={transferInProgress}
             size="md"
+            onSwap={swapChains}
             balance={<DestTokenBalance />}
           />
         </SkPaper>


### PR DESCRIPTION
This PR introduces a new “swap chains” feature in the Bridge UI, allowing users to more intuitively switch the source and destination chains. It also simplifies the BridgeChainCard UI by removing the disabled-state indicator and always displaying the chain description.

Additionally, this change fixes the Base source/destination chain icon visibility issue.

✨ Swap Chains Feature
- Added an optional onSwap prop to the ChainsList component.
- When provided, users can swap source and destination chains by clicking the currently disabled chain.
- If the user selects the disabled chain, the swap handler is invoked; otherwise, the chain selection behaves normally.
Integrated the swapChains method into the MetaportState store and implemented it in MetaportStore.ts.
- Passed swapChains as the onSwap prop from both WidgetBody and BridgeBody to the relevant ChainsList instances, enabling the feature in both contexts.


🎨 UI/UX Improvements
- Simplified BridgeChainCard by:
	- Removing the visual/text indicator for the disabled state.
	- Always displaying the chain description for better clarity and consistency.
	- Fix: Base source/destination chain icons now display correctly.
	- Previously, white icons were hard to see when the card was disabled (grey background).
	- With the updated UI, icons render properly in all states.
	
✅ Result
- More intuitive chain switching UX
- Cleaner and more consistent chain cards
- Fixed visibility issue for Base chain icons


