### PR TITLE
Fix alias display for Ethereum and tokens in history component

### DIFF
--- a/packages/metaport/src/components/History.tsx
+++ b/packages/metaport/src/components/History.tsx
@@ -145,7 +145,6 @@ export default function History(props: {
                   <p
                     className={`${size === 'sm' ? 'text-base' : 'text-lg'} font-bold text-foreground uppercase`}
                   >
-                    {helper.shortAmount(transfer.amount)} {transfer.tokenKeyname}
                   </p>
                   <p
                     className={`text-xs -mt-0.5 flex items-center gap-1 font-semibold ${unfinished || isTrailsFailed(transfer) ? 'text-destructive' : 'text-secondary-foreground'}`}
@@ -264,6 +263,11 @@ function ChainRow(props: {
   short?: boolean
   responsive?: boolean
 }) {
+  const alias = (short?: boolean) => {
+    const name = metadata.getAlias(props.network, props.chainsMeta, props.chainName, undefined, short)
+    return props.responsive ? name.replace(' Mainnet', '') : name
+  }
+
   return (
     <div className="flex items-center gap-1.5">
       <ChainIcon
@@ -275,15 +279,15 @@ function ChainRow(props: {
       {props.responsive ? (
         <>
           <span className="text-xs font-semibold text-foreground capitalize max-md:hidden">
-            {metadata.getAlias(props.network, props.chainsMeta, props.chainName, undefined, true)}
+            {alias(true)}
           </span>
           <span className="text-xs font-semibold text-foreground capitalize md:hidden">
-            {metadata.getAlias(props.network, props.chainsMeta, props.chainName, undefined, false)}
+            {alias(false)}
           </span>
         </>
       ) : (
         <span className="text-xs font-semibold text-foreground capitalize">
-          {metadata.getAlias(props.network, props.chainsMeta, props.chainName, undefined, props.short)}
+          {alias(props.short)}
         </span>
       )}
     </div>

--- a/packages/metaport/src/components/History.tsx
+++ b/packages/metaport/src/components/History.tsx
@@ -21,7 +21,7 @@
  * @copyright SKALE Labs 2023-Present
  */
 
-import { types, helper } from '@/core'
+import { types } from '@/core'
 
 import TokenIcon from './TokenIcon'
 import TransactionData from './TransactionData'


### PR DESCRIPTION
This pull request refactors the way chain aliases are generated and displayed in the `History.tsx` component to improve code readability and maintainability. The main change is the introduction of a helper function to centralize alias logic, and a minor removal of token amount display.

Refactoring and code simplification:

* Introduced an `alias` helper function in `ChainRow` to encapsulate logic for generating chain display names, reducing repetition and making the code more maintainable.
* Updated all usages of `metadata.getAlias` in the JSX to use the new `alias` helper function, ensuring consistent alias formatting throughout the component.

UI change:

* Removed the display of the token amount and key name from the transfer history entry, possibly to simplify the UI or move this information elsewhere.