### PR TITLE
update tos - add third-party tools notice

### DIFF
--- a/src/data/terms-of-service.mdx
+++ b/src/data/terms-of-service.mdx
@@ -14,6 +14,13 @@ Metaport UI Terms of Use (these "<ins>Terms</ins>"). Accordingly, if
 you use the UI, you and we mutually agree that these Terms will
 constitute a binding, legally enforceable contract between you and us.
 
+### Cross-Chain Execution and Third-Party Infrastructure
+The Service may utilize third-party infrastructure, including cross-chain routing, bridging, and messaging protocols, to facilitate transactions across blockchain networks. SKALE does not control these third-party systems and does not guarantee their availability, performance, or security.
+
+Transactions may be automatically routed through one or more execution paths. Users do not select or control the specific bridge or protocol used. Cross-chain transactions involve additional risks, including delays, partial execution, failed execution, and inconsistencies between networks. Funds may become temporarily inaccessible while in transit.
+
+SKALE shall not be liable for any losses arising from third-party protocol failures, exploits, or vulnerabilities. Transaction execution outcomes may vary, and SKALE does not guarantee execution success, timing, or cost.
+
 **THESE TERMS CONTAIN A MANDATORY ARBITRATION PROVISION THAT, AS FURTHER SET FORTH IN THE “ARBITRATION” SECTION BELOW, REQUIRES THE USE OF ARBITRATION ON AN INDIVIDUAL BASIS TO RESOLVE DISPUTES. IT DOES NOT ALLOW JURY TRIALS OR ANY OTHER COURT PROCEEDINGS OR CLASS ACTIONS OF ANY KIND.**
 
 ### NO WARRANTIES


### PR DESCRIPTION
This pull request adds a new section to the Terms of Service clarifying the use of third-party infrastructure for cross-chain execution. The update informs users about the risks and limitations associated with cross-chain transactions and SKALE's lack of control or liability over third-party protocols.

**Cross-chain execution and third-party infrastructure:**

* Added a section explaining that the service may use third-party protocols for cross-chain routing, bridging, and messaging, and that SKALE does not control or guarantee these systems.
* Clarified that users cannot choose the specific bridge or protocol, and outlined the risks involved, such as delays, failed execution, and temporary inaccessibility of funds.
* Stated that SKALE is not liable for losses due to third-party failures, exploits, or vulnerabilities, and does not guarantee transaction outcomes.