### PR TITLE
More fixes Portal 5.1

### DIFF
--- a/packages/metaport/src/components/History.tsx
+++ b/packages/metaport/src/components/History.tsx
@@ -141,7 +141,7 @@ export default function History(props: {
                   size={size === 'sm' ? 'sm' : 'lg'}
                 />
                 <div className={`${size === 'sm' ? 'ml-2.5' : 'ml-3'} min-w-0 flex-1`}>
-                  <Tooltip title={`${transfer.amount} ${transfer.tokenKeyname?.toUpperCase()}`} arrow>
+                  <Tooltip title={`${transfer.amount.includes('.') ? transfer.amount : Number(transfer.amount).toLocaleString()} ${transfer.tokenKeyname?.toUpperCase()}`} arrow>
                     <p
                       className={`${size === 'sm' ? 'text-sm' : 'text-lg'} font-bold text-foreground uppercase truncate`}
                     >

--- a/src/components/ecosystem/Categories.tsx
+++ b/src/components/ecosystem/Categories.tsx
@@ -187,7 +187,7 @@ const CategoryDisplay: React.FC<CategoryDisplayProps> = ({ checkedItems, setChec
           }
         }}
       >
-        <div className="p-2.5">
+        <div className="p-2.5 pb-20 sm:pb-2.5">
           <SearchBar className="mb-5" searchTerm={searchTerm} onSearchChange={handleSearch} />
           {filteredCategories.map(([shortName, data], index) => (
             <div


### PR DESCRIPTION
This pull request introduces small UI improvements to enhance the display of token amounts and improve layout spacing in the application.

- **UI Improvements for Token Amount Display**
  * In `History.tsx`, the tooltip for transfer amounts now formats whole numbers with commas (0.00001 => 0.00001) and without commas just displays the value (Eg: 000000001 SKL => 1 SKL). P1-05 from Karina's findings #829

* Increased the bottom padding of the category container on smaller screens by updating the `className` in the relevant `div` in `Categories.tsx`. P3-06 from Karina's findings #829