### PR TITLE
Fix crash on Bridge Balance page when wallet has 0 ETH

### DIFF
--- a/packages/core/src/units.ts
+++ b/packages/core/src/units.ts
@@ -36,7 +36,8 @@ export function formatBalance(balance: bigint, decimals?: number): string {
   return formatUnits(balance, tokenDecimals)
 }
 
-export function truncateDecimals(input: string, numDecimals: number): string {
+export function truncateDecimals(input: string | null | undefined, numDecimals: number): string {
+  if (!input) return ''
   const delimiter = input.includes(',') ? ',' : '.'
   const [integerPart, decimalPart = ''] = input.split(delimiter)
   return `${integerPart}${delimiter}${decimalPart.slice(0, numDecimals)}`


### PR DESCRIPTION
This pull request updates the `truncateDecimals` utility function in `units.ts` to handle cases where the input may be `null` or `undefined`, improving its robustness.

Error handling improvement:

* Modified `truncateDecimals` to accept `string | null | undefined` as input and return an empty string if the input is falsy, preventing potential runtime errors.