### PR TITLE
Fixed ErrorTile overflow issue 

### DIFF
--- a/src/components/ErrorTile.tsx
+++ b/src/components/ErrorTile.tsx
@@ -35,7 +35,7 @@ export default function ErrorTile(props: {
   return (
     <Collapse in={props.errorMsg !== undefined}>
       <Tile
-        className={`${props.className} mt-5! mb-0! bg-red-100 border-red-200 dark:bg-red-800/80 dark:border-red-600 border-2 items-center! overflow-y-auto! break-all!`}
+        className={`${props.className} mt-5! mb-0! bg-red-100 border-red-200 dark:bg-red-800/80 dark:border-red-600 border-2 items-center! min-w-0! overflow-hidden! break-all!`}
         value={props.errorMsg}
         text="Error occurred"
         icon={<ShieldAlert size={17} />}

--- a/src/components/ErrorTile.tsx
+++ b/src/components/ErrorTile.tsx
@@ -35,7 +35,7 @@ export default function ErrorTile(props: {
   return (
     <Collapse in={props.errorMsg !== undefined}>
       <Tile
-        className={`${props.className} mt-5! mb-0! bg-red-100 border-red-200 dark:bg-red-800/80 dark:border-red-600 border-2 items-center!`}
+        className={`${props.className} mt-5! mb-0! bg-red-100 border-red-200 dark:bg-red-800/80 dark:border-red-600 border-2 items-center! overflow-y-auto! break-all!`}
         value={props.errorMsg}
         text="Error occurred"
         icon={<ShieldAlert size={17} />}
@@ -48,7 +48,7 @@ export default function ErrorTile(props: {
                 if (props.setErrorMsg === undefined) return
                 props.setErrorMsg(undefined)
               }}
-              className="btn btnSm text-foreground! bg-transparent! hover:bg-red-800/10! normal-case!"
+              className="btn btnSm text-foreground! bg-transparent! hover:bg-red-800/10! normal-case! whitespace-nowrap!"
             >
               Close
             </Button>

--- a/src/components/Topup.tsx
+++ b/src/components/Topup.tsx
@@ -27,12 +27,12 @@ import { constants, units, helper, type types } from '@/core'
 import { type MetaportCore, Tile, TokenIcon } from '@skalenetwork/metaport'
 
 import Button from '@mui/material/Button'
-import { Collapse } from '@mui/material'
-import { ClockPlus, ShieldAlert } from 'lucide-react'
+import { ClockPlus } from 'lucide-react'
 
 import SkStack from './SkStack'
 import MonthSelector from './MonthSelector'
 import Loader from './Loader'
+import ErrorTile from './ErrorTile'
 import { formatTimePeriod, monthsBetweenNowAndTimestamp } from '../core/timeHelper'
 
 export default function Topup(props: {
@@ -112,29 +112,7 @@ export default function Topup(props: {
           color={balanceOk ? undefined : 'error'}
         />
       </SkStack>
-      <Collapse in={props.errorMsg !== undefined}>
-        <SkStack className="mt-2.5">
-          <Tile
-            value={props.errorMsg}
-            text="Error occurred"
-            icon={<ShieldAlert size={17} />}
-            color="error"
-            className=" mt-5! mb-0! text-foreground bg-red-100 border-red-200 dark:bg-red-800/80 dark:border-red-600 border-2"
-            grow
-            childrenRi={
-              <Button
-                size="small"
-                onClick={() => {
-                  props.setErrorMsg(undefined)
-                }}
-                className="btn btnSm text-foreground! bg-transparent! hover:bg-red-800/10! normal-case! ml-2.5"
-              >
-                Close
-              </Button>
-            }
-          />
-        </SkStack>
-      </Collapse>
+      <ErrorTile errorMsg={props.errorMsg} setErrorMsg={props.setErrorMsg} />
       <div className="mt-5 mb-2.5 ml-1.5">
         <div className="flex flex-col md:flex-row gap-2.5">
           <Button


### PR DESCRIPTION
This pull request makes small UI improvements to the `ErrorTile` component to enhance error message display and not overflow the tile.

- Improved error message display:
  * Added `overflow-y-auto!` and `break-all!` to the `Tile` class to ensure long error messages are readable and do not overflow the container.

- Improved button appearance:
  * Added `whitespace-nowrap!` to the Close button to prevent the text from wrapping onto multiple lines.