### PR TITLE
Fix for infinite checking balance state on Bridge page after entering amount 

### DIFF
--- a/packages/metaport/src/store/MetaportStore.ts
+++ b/packages/metaport/src/store/MetaportStore.ts
@@ -289,10 +289,12 @@ export const useMetaportStore = create<MetaportState>()((set, get) => ({
     const silent = options?.silent ?? false
     const requestId = ++checkRequestId
     if (get().stepsMetadata[get().currentStep] && address) {
-      set({
-        loading: true,
-        btnText: 'Checking balance...'
-      })
+      if (!silent) {
+        set({
+          loading: true,
+          btnText: 'Checking balance...'
+        })
+      }
       try {
         const stepMetadata = get().stepsMetadata[get().currentStep]
 


### PR DESCRIPTION
This pull request makes a minor change to the `useMetaportStore` hook to improve user experience during the balance checking process. Now, the loading state and button text are only updated when the check is not in silent mode.

* Only set `loading` and update `btnText` to "Checking balance..." if the `silent` option is not enabled, preventing the infinite checking balance state on Bridge page after entering amount #834