### PR TITLE
fix trails integration

### DIFF
--- a/packages/metaport/src/core/actions/trails.ts
+++ b/packages/metaport/src/core/actions/trails.ts
@@ -34,6 +34,7 @@ import {
   waitReceipt,
   encodeDepositERC20Direct,
   wrapWithTrailsRouter,
+  getTrailsRouterAddress,
   TRAILS_ROUTER_PLACEHOLDER_AMOUNT,
   type QuoteIntentResponse
 } from '../trails'
@@ -235,7 +236,13 @@ export class TransferTrailsExt2S extends Action {
       this.address
     )
 
-    const wrapped = wrapWithTrailsRouter(mainnetTokenAddress, depositBoxAddress, rawCallData)
+    const routerAddress = await getTrailsRouterAddress()
+    const wrapped = wrapWithTrailsRouter(
+      mainnetTokenAddress,
+      depositBoxAddress,
+      rawCallData,
+      routerAddress
+    )
 
     try {
       this.trailsQuote = await quoteIntent({

--- a/packages/metaport/src/core/actions/trails.ts
+++ b/packages/metaport/src/core/actions/trails.ts
@@ -22,11 +22,13 @@
  */
 
 import { Logger, type ILogObj } from 'tslog'
+import type { Hash, Hex } from 'viem'
+import type { Provider } from 'ethers'
 import { type types, units } from '@/core'
 
 import { Action } from './action'
 import { checkERC20Balance } from './checks'
-import { getExtChain, isExtChain, NETWORK_MAINNET_CHAINS } from '../network'
+import { enforceNetwork, getExtChain, isExtChain, NETWORK_MAINNET_CHAINS } from '../network'
 import {
   quoteIntent,
   commitIntent,
@@ -68,6 +70,31 @@ function resolveDestTokenAddress(
   return config.connections[destChainName][tokenType][tokenKeyname].address
 }
 
+async function sendTrailsDeposit(
+  action: Action,
+  provider: Provider,
+  chainName: string,
+  depositTx: { to: string; data: string; value: bigint }
+): Promise<Hash> {
+  action.updateState('switch')
+  const { chainId } = await provider.getNetwork()
+  await enforceNetwork(
+    chainId,
+    action.walletClient,
+    action._switchChain,
+    action.mpc.config.skaleNetwork,
+    chainName
+  )
+  action.updateState('trailsDeposit')
+  return action.walletClient.sendTransaction({
+    account: action.walletClient.account!,
+    chain: null,
+    to: depositTx.to as Hex,
+    data: depositTx.data as Hex,
+    value: depositTx.value
+  } as unknown as Parameters<typeof action.walletClient.sendTransaction>[0])
+}
+
 export class TransferTrailsExt2M extends Action {
   trailsQuote: QuoteIntentResponse | null = null
   trailsQuoteError: string | null = null
@@ -86,22 +113,11 @@ export class TransferTrailsExt2M extends Action {
 
     const depositTx = quote.intent.depositTransaction
 
-    this.updateState('switch')
-    const signer = await this.signer(
-      this.sChain1!.provider,
-      this.chainName1
-    )
-
-    this.updateState('trailsDeposit')
-    const tx = await signer.sendTransaction({
-      to: depositTx.to,
-      data: depositTx.data,
-      value: depositTx.value
-    })
-    await tx.wait()
+    const txHash = await sendTrailsDeposit(this, this.sChain1!.provider, this.chainName1, depositTx)
+    await this.sChain1!.provider.waitForTransaction(txHash, 1)
 
     this.updateState('trailsExecuting')
-    await executeIntent(intentId, tx.hash)
+    await executeIntent(intentId, txHash)
 
     this.updateState('trailsWaiting')
     await waitReceipt(intentId)
@@ -170,25 +186,13 @@ export class TransferTrailsExt2S extends Action {
 
     const depositTx = quote.intent.depositTransaction
 
-    this.updateState('switch')
-    const signer = await this.signer(
-      this.sChain1!.provider,
-      this.chainName1
-    )
-
-    this.updateState('trailsDeposit')
-
     const balanceOnDestination = await this.sChain2.getERC20Balance(this.destToken, this.address)
 
-    const tx = await signer.sendTransaction({
-      to: depositTx.to,
-      data: depositTx.data,
-      value: depositTx.value
-    })
-    await tx.wait()
+    const txHash = await sendTrailsDeposit(this, this.sChain1!.provider, this.chainName1, depositTx)
+    await this.sChain1!.provider.waitForTransaction(txHash, 1)
 
     this.updateState('trailsExecuting')
-    await executeIntent(intentId, tx.hash)
+    await executeIntent(intentId, txHash)
 
     this.updateState('trailsWaiting')
     await waitReceipt(intentId)
@@ -294,19 +298,11 @@ export class TransferTrailsM2Ext extends Action {
 
     const depositTx = quote.intent.depositTransaction
 
-    this.updateState('switch')
-    const signer = await this.signer(this.mainnet.provider, 'mainnet')
-
-    this.updateState('trailsDeposit')
-    const tx = await signer.sendTransaction({
-      to: depositTx.to,
-      data: depositTx.data,
-      value: depositTx.value
-    })
-    await tx.wait()
+    const txHash = await sendTrailsDeposit(this, this.mainnet.provider, 'mainnet', depositTx)
+    await this.mainnet.provider.waitForTransaction(txHash, 1)
 
     this.updateState('trailsExecuting')
-    await executeIntent(intentId, tx.hash)
+    await executeIntent(intentId, txHash)
 
     this.updateState('trailsWaiting')
     await waitReceipt(intentId)

--- a/packages/metaport/src/core/trails.ts
+++ b/packages/metaport/src/core/trails.ts
@@ -41,8 +41,6 @@ export type { QuoteIntentResponse, WaitIntentReceiptResponse, IntentReceipt }
 export const TRAILS_ROUTER_PLACEHOLDER_AMOUNT =
   0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefn
 
-const TRAILS_ROUTER_ADDRESS = '0xF8A739B9F24E297a98b7aba7A9cdFDBD457F6fF8'
-
 const log = new Logger<ILogObj>({ name: 'metaport:core:trails' })
 
 const DEPOSIT_ERC20_DIRECT_ABI = [
@@ -87,7 +85,8 @@ function getAmountOffset(calldata: string, placeholder: bigint): number {
 export function wrapWithTrailsRouter(
   token: string,
   target: string,
-  calldata: string
+  calldata: string,
+  routerAddress: string
 ): { callData: `0x${string}`; toAddress: string } {
   const amountOffset = getAmountOffset(calldata, TRAILS_ROUTER_PLACEHOLDER_AMOUNT)
   if (amountOffset === -1) {
@@ -111,7 +110,7 @@ export function wrapWithTrailsRouter(
 
   return {
     callData: encoded,
-    toAddress: TRAILS_ROUTER_ADDRESS
+    toAddress: routerAddress
   }
 }
 
@@ -122,6 +121,17 @@ function getTrailsApi(): TrailsApi {
     trailsApi = new TrailsApi(import.meta.env.VITE_TRAILS_API_KEY)
   }
   return trailsApi
+}
+
+let trailsRouterAddressCache: string | null = null
+
+export async function getTrailsRouterAddress(): Promise<string> {
+  if (trailsRouterAddressCache) return trailsRouterAddressCache
+  const response = await getTrailsApi().getTrailsContracts()
+  const address = response.TrailsContracts.trailsRouterAddress
+  if (!address) throw new Error('Trails router address missing from getTrailsContracts response')
+  trailsRouterAddressCache = address
+  return address
 }
 
 export function encodeDepositERC20Direct(
@@ -161,7 +171,7 @@ export async function quoteIntent(params: TrailsQuoteParams): Promise<QuoteInten
     tradeType: TradeType.EXACT_INPUT,
     options: {
       slippageTolerance: 0.005,
-      bridgeProvider: RouteProvider.RELAY
+      bridgeProvider: RouteProvider.AUTO
     }
   }
   if (params.destinationToAddress) {


### PR DESCRIPTION
This pull request updates how the Trails router address is handled in the Metaport core, making it dynamically fetched instead of hardcoded, and improves the flexibility and reliability of cross-chain transfers. The most significant changes include introducing a function to fetch and cache the router address, updating `wrapWithTrailsRouter` and its usages to accept this address as a parameter, and changing the default bridge provider to automatic selection.

**Dynamic Router Address Handling:**

* Introduced the `getTrailsRouterAddress` function to fetch and cache the Trails router address from the API, removing the previously hardcoded value. This ensures the router address is always up-to-date and configurable.
* Updated `wrapWithTrailsRouter` to accept the router address as a parameter instead of relying on a static constant. [[1]](diffhunk://#diff-b9fec39ed0afbbad4314ff3683b6978d22af6e25ff2e26152e1abce0f8697dd0L90-R89) [[2]](diffhunk://#diff-b9fec39ed0afbbad4314ff3683b6978d22af6e25ff2e26152e1abce0f8697dd0L114-R113)
* Modified `TransferTrailsExt2S` to use the new `getTrailsRouterAddress` function when wrapping call data, ensuring the correct router address is always used.
* Updated imports to include the new `getTrailsRouterAddress` function.
* Removed the hardcoded `TRAILS_ROUTER_ADDRESS` constant from the codebase.

**Bridge Provider Improvements:**

* Changed the default bridge provider in `quoteIntent` from `RELAY` to `AUTO`, allowing the system to automatically select the most appropriate provider for transfers.

**Dependency Update:**

* Updated the `skale-network` submodule to a new commit, likely pulling in upstream improvements or fixes.