### PR TITLE
fix transfers history

### DIFF
--- a/packages/core/src/types/metaport/TransactionHistory.ts
+++ b/packages/core/src/types/metaport/TransactionHistory.ts
@@ -40,6 +40,7 @@ export interface TransferHistory {
   chainName1: string
   chainName2: string
   amount: string
+  timestamp?: number
   trailsIntentId?: string
   trailsStatus?: TrailsTransferStatus
   mesonSwapId?: string

--- a/packages/metaport/src/components/History.tsx
+++ b/packages/metaport/src/components/History.tsx
@@ -64,14 +64,14 @@ function isMesonFailed(transfer: types.mp.TransferHistory): boolean {
 
 function transferTimestamp(transfer: types.mp.TransferHistory): string {
   if (isUnfinished(transfer)) return 'Unfinished'
-  if (isTrailsTransfer(transfer) && transfer.transactions.length === 0) {
-    return isTrailsFailed(transfer) ? 'Failed' : 'Completed'
+  if (transfer.transactions.length > 0) {
+    const last = transfer.transactions[transfer.transactions.length - 1]
+    return timeAgo(last.timestamp)
   }
-  if (isMesonTransfer(transfer) && transfer.transactions.length === 0) {
-    return isMesonFailed(transfer) ? 'Failed' : 'Completed'
-  }
-  const last = transfer.transactions[transfer.transactions.length - 1]
-  return timeAgo(last.timestamp)
+  if (transfer.timestamp) return timeAgo(transfer.timestamp)
+  if (isTrailsTransfer(transfer)) return isTrailsFailed(transfer) ? 'Failed' : 'Completed'
+  if (isMesonTransfer(transfer)) return isMesonFailed(transfer) ? 'Failed' : 'Completed'
+  return ''
 }
 
 function shortenValue(value: string | number, length: number = 8): string {
@@ -187,11 +187,9 @@ export default function History(props: {
                           {transfer.tokenKeyname}
                         </p>
                       </Tooltip>
-                      {!hasProvider && (
-                        <p className="text-sm font-semibold text-muted-foreground m-0">
-                          {transferTimestamp(transfer)}
-                        </p>
-                      )}
+                      <p className={`${size === 'sm' ? 'text-xs' : 'text-sm'} font-semibold text-muted-foreground m-0`}>
+                        {transferTimestamp(transfer)}
+                      </p>
                     </div>
                   </div>
                   {size === 'sm' ? (

--- a/packages/metaport/src/store/MetaportStore.ts
+++ b/packages/metaport/src/store/MetaportStore.ts
@@ -228,7 +228,8 @@ export const useMetaportStore = create<MetaportState>()((set, get) => ({
           chainName2: get().chainName2,
           amount: get().amount,
           tokenKeyname: get().token.keyname,
-          address: address
+          address: address,
+          timestamp: Math.floor(Date.now() / 1000)
         }
         const intentId = get().trailsIntentId
         if (intentId) {


### PR DESCRIPTION
This pull request introduces improvements to how transfer timestamps are handled and displayed in the transaction history. The main changes add a `timestamp` field to the `TransferHistory` type, ensure timestamps are set when creating new transfers, and update the timestamp display logic for better accuracy and consistency.

**Data Model Updates:**

* Added an optional `timestamp` field to the `TransferHistory` interface in `TransactionHistory.ts` to record the time of each transfer.

**Transfer Creation Logic:**

* Updated the transfer creation logic in `MetaportStore.ts` to set the `timestamp` to the current Unix time when a new transfer is recorded.

**UI and Display Improvements:**

* Improved the `transferTimestamp` function in `History.tsx` to use the new `timestamp` field if available, providing more accurate time information for transfers without transaction records. The function now also handles cases where there are no transactions more gracefully.
* Updated the rendering logic in `History.tsx` to always display the transfer timestamp, regardless of provider status, and to adjust the text size based on the component size.