### PR TITLE
New approach for the error handling

### DIFF
--- a/packages/core/src/notify.ts
+++ b/packages/core/src/notify.ts
@@ -33,16 +33,16 @@ function temporaryInfo(message: string, toastId?: string | number) {
     toast.info(message, { duration: DEFAULT_DURATION, id: toastId, className: "text-sky-500! dark:text-blue-400! bg-sky-100! dark:bg-blue-400/15! backdrop-blur-md!" })
 }
 
-const ERROR_DESCRIPTION = 'Check browser console for details'
+const ERROR_DESCRIPTION = 'Check browser\'s developer console'
 
-function permanentError(message: string, toastId?: string | number) {
+function permanentError(message: string, toastId?: string | number, showDescription = true) {
     const trimmed = message.split(/[.\n(]/)[0].trim().slice(0, 80) || message.slice(0, 80)
     const short = trimmed.charAt(0).toUpperCase() + trimmed.slice(1)
-    toast.error(short, { duration: Infinity, id: toastId, description: ERROR_DESCRIPTION, className: "text-red-500! dark:text-red-400! bg-red-100! dark:bg-red-400/15! backdrop-blur-md!" })
+    toast.error(short, { duration: Infinity, id: toastId, description: showDescription ? ERROR_DESCRIPTION : undefined, className: "text-red-500! dark:text-red-400! bg-red-100! dark:bg-red-400/15! backdrop-blur-md!" })
 }
 
 function temporaryError(message: string, toastId?: string | number) {
-    toast.error(message, { duration: DEFAULT_DURATION, id: toastId, description: ERROR_DESCRIPTION, className: "text-red-500! dark:text-red-400! bg-red-100! dark:bg-red-400/15! backdrop-blur-md!" })
+    toast.error(message, { duration: DEFAULT_DURATION, id: toastId, className: "text-red-500! dark:text-red-400! bg-red-100! dark:bg-red-400/15! backdrop-blur-md!" })
 }
 
 function loading(message: string, options?: any): string | number {

--- a/packages/core/src/notify.ts
+++ b/packages/core/src/notify.ts
@@ -33,12 +33,16 @@ function temporaryInfo(message: string, toastId?: string | number) {
     toast.info(message, { duration: DEFAULT_DURATION, id: toastId, className: "text-sky-500! dark:text-blue-400! bg-sky-100! dark:bg-blue-400/15! backdrop-blur-md!" })
 }
 
+const ERROR_DESCRIPTION = 'Check browser console for details'
+
 function permanentError(message: string, toastId?: string | number) {
-    toast.error(message, { duration: Infinity, id: toastId, className: "text-red-500! dark:text-red-400! bg-red-100! dark:bg-red-400/15! backdrop-blur-md!" })
+    const trimmed = message.split(/[.\n(]/)[0].trim().slice(0, 80) || message.slice(0, 80)
+    const short = trimmed.charAt(0).toUpperCase() + trimmed.slice(1)
+    toast.error(short, { duration: Infinity, id: toastId, description: ERROR_DESCRIPTION, className: "text-red-500! dark:text-red-400! bg-red-100! dark:bg-red-400/15! backdrop-blur-md!" })
 }
 
 function temporaryError(message: string, toastId?: string | number) {
-    toast.error(message, { duration: DEFAULT_DURATION, id: toastId, className: "text-red-500! dark:text-red-400! bg-red-100! dark:bg-red-400/15! backdrop-blur-md!" })
+    toast.error(message, { duration: DEFAULT_DURATION, id: toastId, description: ERROR_DESCRIPTION, className: "text-red-500! dark:text-red-400! bg-red-100! dark:bg-red-400/15! backdrop-blur-md!" })
 }
 
 function loading(message: string, options?: any): string | number {

--- a/packages/metaport/src/components/AddToken.tsx
+++ b/packages/metaport/src/components/AddToken.tsx
@@ -92,10 +92,10 @@ export default function AddToken(props: {
       if (wasAdded) {
         notify.temporarySuccess('Token added to wallet')
       } else {
-        notify.permanentError('Token was not added')
+        notify.permanentError('Token was not added', undefined, false)
       }
     } catch (error) {
-      notify.permanentError('Failed to add token')
+      notify.permanentError('Failed to add token', undefined, false)
     } finally {
       setLoading(false)
     }

--- a/packages/metaport/src/components/ErrorMessage.tsx
+++ b/packages/metaport/src/components/ErrorMessage.tsx
@@ -43,6 +43,7 @@ import {
 } from 'lucide-react'
 
 import { DEFAULT_ERROR_MSG } from '../core/constants'
+import { extractFirstSentence } from '../utils/helper'
 
 const ERROR_ICONS = {
   'link-off': <Link2Off />,
@@ -70,7 +71,7 @@ export default function Error(props: { errorMessage: dc.ErrorMessage }) {
         style={{ wordBreak: 'break-word' }}
         className="text-base text-orange-600 font-semibold grow text-center mt-2.5"
       >
-        {props.errorMessage.headline ?? DEFAULT_ERROR_MSG}
+        {extractFirstSentence(props.errorMessage.headline ?? DEFAULT_ERROR_MSG)}
       </p>
       <p className="text-xs text-secondary-foreground font-medium grow text-center mb-2.5">
         Logs are available in your browser's developer console
@@ -133,7 +134,7 @@ export default function Error(props: { errorMessage: dc.ErrorMessage }) {
               style={{ wordBreak: 'break-all' }}
               className="text-xs text-muted-foreground grow text-center ml-2.5 mr-2.5 mb-5"
             >
-              {props.errorMessage.text}
+              {extractFirstSentence(props.errorMessage.text)}
             </code>
           </div>
         </AccordionDetails>

--- a/packages/metaport/src/components/SFuelWarning.tsx
+++ b/packages/metaport/src/components/SFuelWarning.tsx
@@ -167,7 +167,7 @@ export default function SFuelWarning(props: {}) {
       if (fromPowRes) log.info(chainName1, fromPowRes.message)
       if (toPowRes) log.info(chainName2, toPowRes.message)
       if (hubPowRes) log.info(hubChain, hubPowRes.message)
-      notify.permanentError('Failed to get sFUEL', toastId)
+      notify.permanentError('Failed to get sFUEL', toastId, false)
     } else {
       notify.temporarySuccess('sFUEL received', toastId)
     }

--- a/packages/metaport/src/core/actions/bridge_balance.ts
+++ b/packages/metaport/src/core/actions/bridge_balance.ts
@@ -143,7 +143,7 @@ export async function withdraw(
     setLoading(false)
   } catch (err) {
     const msg = err.message ? err.message : DEFAULT_ERROR_MSG
-    notify.permanentError(msg, toastId)
+    notify.permanentError(msg, toastId, false)
     setErrorMessage(new dc.TransactionErrorMessage(msg, errorMessageClosedFallback))
   }
 }
@@ -197,7 +197,7 @@ export async function recharge(
     notify.temporarySuccess('Bridge balance topped up', toastId)
   } catch (err) {
     const msg = err.message ? err.message : DEFAULT_ERROR_MSG
-    notify.permanentError(msg, toastId)
+    notify.permanentError(msg, toastId, false)
     setErrorMessage(new dc.TransactionErrorMessage(msg, errorMessageClosedFallback))
   } finally {
     setLoading(false)

--- a/packages/metaport/src/core/network.ts
+++ b/packages/metaport/src/core/network.ts
@@ -182,13 +182,14 @@ export async function enforceNetwork(
   }
   try {
     // tmp fix for coinbase wallet
-    _networkSwitch(chainId, currentChainId, switchChain)
+    await _networkSwitch(chainId, currentChainId, switchChain)
   } catch (e) {
+    if (e.code === 'ACTION_REJECTED' || e.code === 4001) throw e
     log.info('Failed to switch network, retrying...')
     await helper.sleep(constants.DEFAULT_SLEEP)
-    _networkSwitch(chainId, currentChainId, switchChain)
+    await _networkSwitch(chainId, currentChainId, switchChain)
   }
-  await waitForNetworkChange(walletClient, currentChainId, chainId)
+  await waitForNetworkChange(walletClient, currentChainId, chainId, 2000, 15)
   await helper.sleep(constants.DEFAULT_SLEEP)
   log.info(`Network switched to ${chainId}`)
   return chainId

--- a/packages/metaport/src/store/MetaportStore.ts
+++ b/packages/metaport/src/store/MetaportStore.ts
@@ -37,6 +37,7 @@ import { ActionConstructor } from '../core/actions/action'
 import { isTrailsAction } from '../core/actions/trails'
 import { isMesonAction } from '../core/actions/meson'
 import { getEmptyCommunityPoolData, getCommunityPoolData } from '../core/community_pool'
+import { TimeoutException } from '../core/exceptions'
 
 const log = new Logger<ILogObj>({ name: 'metaport:core:state' })
 let checkRequestId = 0
@@ -191,7 +192,9 @@ export const useMetaportStore = create<MetaportState>()((set, get) => ({
         console.error(err)
         const msg = err.message
         let headline
-        if (err.code && err.code === 'ACTION_REJECTED') {
+        if (err instanceof TimeoutException) {
+          headline = 'Network switch timed out'
+        } else if (err.code && err.code === 'ACTION_REJECTED') {
           headline = 'Transaction signing was rejected'
         } else {
           headline = TRANSFER_ERROR_MSG

--- a/packages/metaport/src/store/MetaportStore.ts
+++ b/packages/metaport/src/store/MetaportStore.ts
@@ -202,6 +202,7 @@ export const useMetaportStore = create<MetaportState>()((set, get) => ({
         if (err.shortMessage) {
           headline = err.shortMessage
         }
+        headline = headline.split(/[.\n(]/)[0].trim()
         headline = headline.charAt(0).toUpperCase() + headline.slice(1)
 
         notify.permanentError(headline)

--- a/src/components/GetSFuel.tsx
+++ b/src/components/GetSFuel.tsx
@@ -53,7 +53,7 @@ function SingleChainSFuel({ chainName, mpc }: { chainName: string; mpc: Metaport
       try {
         const { ok: mined } = await station.doPoW(addr)
         if (!mined) {
-          notify.permanentError('Failed to get sFUEL', toastId)
+          notify.permanentError('Failed to get sFUEL', toastId, false)
           return
         }
         await new Promise((r) => setTimeout(r, 3000))
@@ -63,7 +63,7 @@ function SingleChainSFuel({ chainName, mpc }: { chainName: string; mpc: Metaport
         if (ok) {
           notify.temporarySuccess('sFUEL received', toastId)
         } else {
-          notify.permanentError('Failed to get sFUEL', toastId)
+          notify.permanentError('Failed to get sFUEL', toastId, false)
         }
       } finally {
         setLoading(false)

--- a/src/components/MonthSelector.tsx
+++ b/src/components/MonthSelector.tsx
@@ -98,11 +98,11 @@ export default function MonthSelector(props: {
                   !Number.isInteger(Number(textPeriod)) ||
                   Number(textPeriod) <= 0
                 ) {
-                  notify.temporaryError('Incorrect top-up period')
+                  notify.permanentError('Incorrect top-up period', undefined, false)
                   return
                 }
                 if (props.max < Number(textPeriod)) {
-                  notify.temporaryError(`Max topup amount: ${formatTimePeriod(props.max, 'month')}`)
+                  notify.permanentError(`Max topup amount: ${formatTimePeriod(props.max, 'month')}`, undefined, false)
                   return
                 }
                 setOpenCustom(false)

--- a/src/components/MonthSelector.tsx
+++ b/src/components/MonthSelector.tsx
@@ -35,7 +35,6 @@ export default function MonthSelector(props: {
   max: number
   topupPeriod: number
   setTopupPeriod: any
-  setErrorMsg: (errorMsg: string | undefined) => void
   className?: string
 }) {
   const [monthRecommendations, setMonthRecommendations] = useState<number[]>(MONTH_RECOMMENDATIONS)
@@ -100,12 +99,10 @@ export default function MonthSelector(props: {
                   Number(textPeriod) <= 0
                 ) {
                   notify.temporaryError('Incorrect top-up period')
-                  props.setErrorMsg('Incorrect top-up period')
                   return
                 }
                 if (props.max < Number(textPeriod)) {
                   notify.temporaryError(`Max topup amount: ${formatTimePeriod(props.max, 'month')}`)
-                  props.setErrorMsg(`Max topup amount: ${formatTimePeriod(props.max, 'month')}`)
                   return
                 }
                 setOpenCustom(false)
@@ -113,7 +110,6 @@ export default function MonthSelector(props: {
                   setCustomPeriod(Number(textPeriod))
                 }
                 props.setTopupPeriod(Number(textPeriod))
-                props.setErrorMsg(undefined)
               }}
             >
               <p className=" text-foreground! ml-1.5">Apply</p>

--- a/src/components/Paymaster.tsx
+++ b/src/components/Paymaster.tsx
@@ -57,7 +57,6 @@ export default function Paymaster(props: {
   const paymasterChain = contracts.paymaster.getPaymasterChain(network)
 
   const [btnText, setBtnText] = useState<string | undefined>()
-  const [errorMsg, setErrorMsg] = useState<string | undefined>()
   const [loading, setLoading] = useState<boolean>(false)
   const [inited, setInited] = useState<boolean>(false)
 
@@ -105,13 +104,11 @@ export default function Paymaster(props: {
   async function topupChain() {
     if (!paymaster) return
     if (!paymaster.runner?.provider || !walletClient || !switchChainAsync) {
-      setErrorMsg('Something is wrong with your wallet, try again')
       notify.permanentError('Something is wrong with your wallet, try again')
       return
     }
     setLoading(true)
     setBtnText(`Switch network to ${metadata.getAlias(network, props.chainsMeta, paymasterChain)}`)
-    setErrorMsg(undefined)
     try {
       const { chainId } = await paymaster.runner.provider.getNetwork()
       const paymasterAddress = contracts.paymaster.getPaymasterAddress(network)
@@ -139,7 +136,6 @@ export default function Paymaster(props: {
       await loadPaymasterInfo()
     } catch (e: any) {
       const errMsg = e.toString()
-      setErrorMsg(errMsg)
       notify.permanentError(errMsg)
     } finally {
       setLoading(false)
@@ -198,8 +194,6 @@ export default function Paymaster(props: {
           topupChain={topupChain}
           btnText={btnText}
           loading={loading}
-          errorMsg={errorMsg}
-          setErrorMsg={setErrorMsg}
         />
       )}
     </div>

--- a/src/components/Paymaster.tsx
+++ b/src/components/Paymaster.tsx
@@ -104,7 +104,7 @@ export default function Paymaster(props: {
   async function topupChain() {
     if (!paymaster) return
     if (!paymaster.runner?.provider || !walletClient || !switchChainAsync) {
-      notify.permanentError('Something is wrong with your wallet, try again')
+      notify.permanentError('Something is wrong with your wallet, try again', undefined, false)
       return
     }
     setLoading(true)

--- a/src/components/SchainDetails.tsx
+++ b/src/components/SchainDetails.tsx
@@ -95,8 +95,12 @@ export default function SchainDetails(props: {
       })
       setAdded(true)
       notify.temporarySuccess(`Connected to ${networkParams.chainName}`)
-    } catch (e) {
-      console.error(e)
+    } catch (e: any) {
+      if (e?.code === 4001) {
+        notify.temporaryError('Connect to chain cancelled')
+      } else {
+        notify.permanentError('Failed to connect chain', undefined, false)
+      }
     } finally {
       setLoading(false)
     }

--- a/src/components/SchainDetails.tsx
+++ b/src/components/SchainDetails.tsx
@@ -97,7 +97,7 @@ export default function SchainDetails(props: {
       notify.temporarySuccess(`Connected to ${networkParams.chainName}`)
     } catch (e: any) {
       if (e?.code === 4001) {
-        notify.temporaryError('Connect to chain cancelled')
+        notify.permanentError('Connect to chain cancelled', undefined, false)
       } else {
         notify.permanentError('Failed to connect chain', undefined, false)
       }

--- a/src/components/Topup.tsx
+++ b/src/components/Topup.tsx
@@ -32,7 +32,6 @@ import { ClockPlus } from 'lucide-react'
 import SkStack from './SkStack'
 import MonthSelector from './MonthSelector'
 import Loader from './Loader'
-import ErrorTile from './ErrorTile'
 import { formatTimePeriod, monthsBetweenNowAndTimestamp } from '../core/timeHelper'
 
 export default function Topup(props: {
@@ -44,8 +43,6 @@ export default function Topup(props: {
   tokenBalance: bigint | undefined
   topupChain: () => Promise<void>
   btnText: string | undefined
-  errorMsg: string | undefined
-  setErrorMsg: (errorMsg: string | undefined) => void
   loading: boolean
 }) {
   if (props.tokenBalance === undefined) return <Loader text="Loading balance info" />
@@ -80,7 +77,6 @@ export default function Topup(props: {
               max={maxTopupPeriod}
               topupPeriod={props.topupPeriod}
               setTopupPeriod={props.setTopupPeriod}
-              setErrorMsg={props.setErrorMsg}
             />
           }
           className="w-full!"
@@ -112,7 +108,6 @@ export default function Topup(props: {
           color={balanceOk ? undefined : 'error'}
         />
       </SkStack>
-      <ErrorTile errorMsg={props.errorMsg} setErrorMsg={props.setErrorMsg} />
       <div className="mt-5 mb-2.5 ml-1.5">
         <div className="flex flex-col md:flex-row gap-2.5">
           <Button

--- a/src/components/credits/ChainCreditsTile.tsx
+++ b/src/components/credits/ChainCreditsTile.tsx
@@ -68,7 +68,6 @@ interface ChainCreditsTileProps {
   creditStation: Contract | undefined
   tokenPrices: Record<string, bigint>
   tokenBalances: types.mp.TokenBalancesMap | undefined
-  setErrorMsg: (msg: string | undefined) => void
 }
 
 const ChainCreditsTile: React.FC<ChainCreditsTileProps> = ({
@@ -77,8 +76,7 @@ const ChainCreditsTile: React.FC<ChainCreditsTileProps> = ({
   schain,
   creditStation,
   tokenPrices,
-  tokenBalances,
-  setErrorMsg
+  tokenBalances
 }) => {
   const [openModal, setOpenModal] = useState(false)
   const [loading, setLoading] = useState<boolean>(false)
@@ -148,13 +146,11 @@ const ChainCreditsTile: React.FC<ChainCreditsTileProps> = ({
   async function buyCredits() {
     if (!creditStation || !token) return
     if (!creditStation.runner?.provider || !walletClient || !switchChainAsync) {
-      setErrorMsg('Something is wrong with your wallet, try again')
       notify.permanentError('Something is wrong with your wallet, try again')
       setOpenModal(false)
       return
     }
     setLoading(true)
-    setErrorMsg(undefined)
 
     try {
       const tokenAddress = tokens[token].address
@@ -191,7 +187,6 @@ const ChainCreditsTile: React.FC<ChainCreditsTileProps> = ({
       notify.temporarySuccess(`Credits purchased for ${chainAlias}`)
     } catch (e: any) {
       const errMsg = e.toString()
-      setErrorMsg(errMsg)
       notify.permanentError(errMsg)
     } finally {
       setLoading(false)

--- a/src/components/credits/ChainCreditsTile.tsx
+++ b/src/components/credits/ChainCreditsTile.tsx
@@ -146,7 +146,7 @@ const ChainCreditsTile: React.FC<ChainCreditsTileProps> = ({
   async function buyCredits() {
     if (!creditStation || !token) return
     if (!creditStation.runner?.provider || !walletClient || !switchChainAsync) {
-      notify.permanentError('Something is wrong with your wallet, try again')
+      notify.permanentError('Something is wrong with your wallet, try again', undefined, false)
       setOpenModal(false)
       return
     }

--- a/src/components/credits/CreditStationStatusTile.tsx
+++ b/src/components/credits/CreditStationStatusTile.tsx
@@ -69,7 +69,7 @@ const CreditStationStatusTile: React.FC<CreditStationStatusTileProps> = ({
   async function togglePause() {
     if (!creditStation) return
     if (!creditStation.runner?.provider || !walletClient || !switchChainAsync) {
-      notify.permanentError('Something is wrong with your wallet, try again')
+      notify.permanentError('Something is wrong with your wallet, try again', undefined, false)
       return
     }
     setLoading(true)
@@ -90,7 +90,7 @@ const CreditStationStatusTile: React.FC<CreditStationStatusTileProps> = ({
       notify.temporarySuccess(`Credit station ${action}d`)
       await loadPausedStatus()
     } catch (error) {
-      notify.permanentError('Transaction failed')
+      notify.permanentError('Transaction failed', undefined, false)
     } finally {
       setLoading(false)
     }

--- a/src/components/credits/CreditStationStatusTile.tsx
+++ b/src/components/credits/CreditStationStatusTile.tsx
@@ -38,13 +38,11 @@ import { Badge, BadgeCheck, ToggleLeft, ToggleRight } from 'lucide-react'
 interface CreditStationStatusTileProps {
   mpc: MetaportCore
   creditStation: Contract | undefined
-  setErrorMsg: (msg: string) => void
 }
 
 const CreditStationStatusTile: React.FC<CreditStationStatusTileProps> = ({
   mpc,
-  creditStation,
-  setErrorMsg
+  creditStation
 }) => {
   const [isPaused, setIsPaused] = useState<boolean>(false)
   const [loading, setLoading] = useState<boolean>(false)
@@ -71,7 +69,6 @@ const CreditStationStatusTile: React.FC<CreditStationStatusTileProps> = ({
   async function togglePause() {
     if (!creditStation) return
     if (!creditStation.runner?.provider || !walletClient || !switchChainAsync) {
-      setErrorMsg('Something is wrong with your wallet, try again')
       notify.permanentError('Something is wrong with your wallet, try again')
       return
     }
@@ -93,7 +90,6 @@ const CreditStationStatusTile: React.FC<CreditStationStatusTileProps> = ({
       notify.temporarySuccess(`Credit station ${action}d`)
       await loadPausedStatus()
     } catch (error) {
-      setErrorMsg('Transaction failed')
       notify.permanentError('Transaction failed')
     } finally {
       setLoading(false)

--- a/src/components/credits/CreditsPaymentTile.tsx
+++ b/src/components/credits/CreditsPaymentTile.tsx
@@ -57,7 +57,6 @@ interface CreditsPaymentTileProps {
   ledgerContract: Contract | undefined
   creditStation: Contract | undefined
   isAdmin?: boolean
-  setErrorMsg: (msg: string | undefined) => void
 }
 
 const CreditsPaymentTile: React.FC<CreditsPaymentTileProps> = ({
@@ -66,8 +65,7 @@ const CreditsPaymentTile: React.FC<CreditsPaymentTileProps> = ({
   chainsMeta,
   ledgerContract,
   creditStation,
-  isAdmin = false,
-  setErrorMsg
+  isAdmin = false
 }) => {
   const network = mpc.config.skaleNetwork
   const chainAlias = metadata.getAlias(network, chainsMeta, payment.schainName)
@@ -94,7 +92,7 @@ const CreditsPaymentTile: React.FC<CreditsPaymentTileProps> = ({
         if (!provider) return
         const block = await provider.getBlock(payment.blockNumber)
         if (block) setTxTimestamp(block.timestamp)
-      } catch (error) {}
+      } catch (error) { }
     }
     fetchTimestamp()
   }, [creditStation, payment])
@@ -104,7 +102,7 @@ const CreditsPaymentTile: React.FC<CreditsPaymentTileProps> = ({
     const checkFulfillment = async () => {
       try {
         setIsFulfilled(await ledgerContract.isFulfilled(payment.id))
-      } catch (error) {}
+      } catch (error) { }
     }
     checkFulfillment()
     const interval = setInterval(checkFulfillment, 10000)
@@ -114,7 +112,6 @@ const CreditsPaymentTile: React.FC<CreditsPaymentTileProps> = ({
   async function fulfillPayment() {
     if (!ledgerContract) return
     setLoading(true)
-    setErrorMsg(undefined)
 
     try {
       const signer = await cs.prepareSignerForWrite(
@@ -136,7 +133,6 @@ const CreditsPaymentTile: React.FC<CreditsPaymentTileProps> = ({
       notify.temporarySuccess('Payment fulfilled')
     } catch (e: any) {
       const errMsg = e.toString()
-      setErrorMsg(errMsg)
       notify.permanentError(errMsg)
     } finally {
       setLoading(false)

--- a/src/components/credits/TokenAdminTile.tsx
+++ b/src/components/credits/TokenAdminTile.tsx
@@ -53,7 +53,6 @@ interface TokenAdminTileProps {
   tokenMeta: types.mp.TokenMetadata | undefined
   tokenData: types.mp.Token
   symbol: string
-  setErrorMsg: (msg: string) => void
 }
 
 const TokenAdminTile: React.FC<TokenAdminTileProps> = ({

--- a/src/components/credits/TokenAdminTile.tsx
+++ b/src/components/credits/TokenAdminTile.tsx
@@ -85,7 +85,7 @@ const TokenAdminTile: React.FC<TokenAdminTileProps> = ({
   async function updatePrice() {
     if (!creditStation || price === '') return
     if (!creditStation.runner?.provider || !walletClient || !switchChainAsync) {
-      notify.permanentError('Something is wrong with your wallet, try again')
+      notify.permanentError('Something is wrong with your wallet, try again', undefined, false)
       setOpenModal(false)
       return
     }

--- a/src/components/credits/TokensAdmin.tsx
+++ b/src/components/credits/TokensAdmin.tsx
@@ -31,7 +31,6 @@ import HistoryRoundedIcon from '@mui/icons-material/HistoryRounded'
 
 import TokenAdminTile from './TokenAdminTile'
 import AccordionSection from '../AccordionSection'
-import ErrorTile from '../ErrorTile'
 import CreditsHistoryTile from './CreditsPaymentTile'
 import CreditStationStatusTile from './CreditStationStatusTile'
 import { getTokenPrices } from '../../core/credit-station'
@@ -53,7 +52,6 @@ const CreditTokensAdmin: React.FC<CreditTokensAdminProps> = ({
   const tokens = mpc.config.connections.mainnet?.erc20
   const tokensMeta = mpc.config.tokens
 
-  const [errorMsg, setErrorMsg] = useState<string | undefined>(undefined)
   const [tokenPrices, setTokenPrices] = useState<Record<string, bigint>>({})
   const [allPayments, setAllPayments] = useState<cs.Payment[]>([])
   const [ledgerContracts, setLedgerContracts] = useState<{ [schainName: string]: Contract }>({})
@@ -85,7 +83,6 @@ const CreditTokensAdmin: React.FC<CreditTokensAdminProps> = ({
 
   return (
     <div>
-      <ErrorTile errorMsg={errorMsg} className="mb-2.5" />
       <SkPaper gray className="mt-5">
         <AccordionSection
           expandedByDefault={true}
@@ -96,7 +93,6 @@ const CreditTokensAdmin: React.FC<CreditTokensAdminProps> = ({
           <CreditStationStatusTile
             mpc={mpc}
             creditStation={creditStation}
-            setErrorMsg={setErrorMsg}
           />
         </AccordionSection>
       </SkPaper>
@@ -118,7 +114,6 @@ const CreditTokensAdmin: React.FC<CreditTokensAdminProps> = ({
                 tokenMeta={tokensMeta[symbol]}
                 tokenData={tokenData}
                 symbol={symbol}
-                setErrorMsg={setErrorMsg}
               />
             ))}
           </div>
@@ -157,7 +152,6 @@ const CreditTokensAdmin: React.FC<CreditTokensAdminProps> = ({
                   ledgerContract={ledgerContracts[payment.schainName]}
                   creditStation={creditStation}
                   isAdmin={true}
-                  setErrorMsg={setErrorMsg}
                 />
               ))}
           </div>

--- a/src/components/delegation/ChainRewards.tsx
+++ b/src/components/delegation/ChainRewards.tsx
@@ -42,7 +42,6 @@ import { Button, IconButton, Tooltip } from '@mui/material'
 import { Blocks, CalendarArrowDown, CircleStar } from 'lucide-react'
 
 import Headline from '../Headline'
-import ErrorTile from '../ErrorTile'
 import SkStack from '../SkStack'
 
 interface ChainRewardsProps {
@@ -69,7 +68,6 @@ const ChainRewards: React.FC<ChainRewardsProps> = ({
   const [sklPrice, setSklPrice] = useState<bigint | undefined>(undefined)
 
   const [btnText, setBtnText] = useState<string | undefined>()
-  const [errorMsg, setErrorMsg] = useState<string | undefined>()
   const [loading, setLoading] = useState<boolean>(false)
   const [paymaster, setPaymaster] = useState<Contract | undefined>()
 
@@ -142,13 +140,11 @@ const ChainRewards: React.FC<ChainRewardsProps> = ({
       !switchChainAsync ||
       !address
     ) {
-      setErrorMsg('Something is wrong with your wallet, try again')
       notify.permanentError('Something is wrong with your wallet, try again')
       return
     }
     setLoading(true)
     setBtnText('Switching network')
-    setErrorMsg(undefined)
     const toastId = notify.loading('Retrieving rewards...')
     try {
       const sFuelBalance = await paymaster.runner.provider.getBalance(address)
@@ -158,7 +154,6 @@ const ChainRewards: React.FC<ChainRewardsProps> = ({
         const station = new Station(paymasterChain, mpc)
         const powResult = await station.doPoW(address)
         if (!powResult.ok) {
-          setErrorMsg('Failed to mine sFUEL')
           notify.permanentError('Failed to mine sFUEL', toastId)
           return
         }
@@ -177,7 +172,6 @@ const ChainRewards: React.FC<ChainRewardsProps> = ({
       await loadData()
     } catch (e: any) {
       const errMsg = e.toString()
-      setErrorMsg(errMsg)
       notify.permanentError(errMsg, toastId)
     } finally {
       setLoading(false)
@@ -246,7 +240,6 @@ const ChainRewards: React.FC<ChainRewardsProps> = ({
           </SkStack>
         }
       />
-      <ErrorTile errorMsg={errorMsg} setErrorMsg={setErrorMsg} />
     </SkPaper>
   )
 }

--- a/src/components/delegation/ChainRewards.tsx
+++ b/src/components/delegation/ChainRewards.tsx
@@ -140,7 +140,7 @@ const ChainRewards: React.FC<ChainRewardsProps> = ({
       !switchChainAsync ||
       !address
     ) {
-      notify.permanentError('Something is wrong with your wallet, try again')
+      notify.permanentError('Something is wrong with your wallet, try again', undefined, false)
       return
     }
     setLoading(true)
@@ -154,7 +154,7 @@ const ChainRewards: React.FC<ChainRewardsProps> = ({
         const station = new Station(paymasterChain, mpc)
         const powResult = await station.doPoW(address)
         if (!powResult.ok) {
-          notify.permanentError('Failed to mine sFUEL', toastId)
+          notify.permanentError('Failed to mine sFUEL', toastId, false)
           return
         }
       }

--- a/src/components/delegation/Delegate.tsx
+++ b/src/components/delegation/Delegate.tsx
@@ -21,7 +21,7 @@
  */
 
 import { Logger, type ILogObj } from 'tslog'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { type Signer } from 'ethers'
 
@@ -40,7 +40,6 @@ import { TextField, Tooltip } from '@mui/material'
 import { ArrowDown, CalendarSync, Clock, Share2 } from 'lucide-react'
 
 import SkStack from '../SkStack'
-import ErrorTile from '../ErrorTile'
 import Loader from '../Loader'
 import DelegationFlow from './DelegationFlow'
 import { notify } from '@/core'
@@ -56,8 +55,6 @@ export default function Delegate(props: {
   delegationType: types.st.DelegationType
   loaded: boolean
   delegationTypeAvailable: boolean
-  errorMsg: string | undefined
-  setErrorMsg: (msg: string | undefined) => void
   className?: string
   sklPrice: bigint
 }) {
@@ -67,11 +64,17 @@ export default function Delegate(props: {
 
   const navigate = useNavigate()
 
+  useEffect(() => {
+    if (props.loaded && !props.delegationTypeAvailable && props.address) {
+      notify.permanentError('Delegation type is not available')
+    }
+  }, [props.loaded, props.delegationTypeAvailable, props.address])
+
   if (!props.loaded || !props.validator) {
     return <Loader text="Loading staking info" />
   }
   if (props.loaded && !props.delegationTypeAvailable && props.address) {
-    return <ErrorTile errorMsg="Delegation type is not available" />
+    return null
   }
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -86,7 +89,7 @@ export default function Delegate(props: {
   async function stake() {
     setLoading(true)
     if (props.validator === undefined) {
-      props.setErrorMsg('Validator not found')
+      notify.permanentError('Validator not found')
       setLoading(false)
       return
     }
@@ -119,7 +122,6 @@ export default function Delegate(props: {
     } catch (err: any) {
       log.error(err)
       const errMsg = err.message ? err.message : constants.DEFAULT_ERROR_MSG
-      props.setErrorMsg(errMsg)
       notify.permanentError(errMsg)
       setLoading(false)
     }
@@ -233,8 +235,6 @@ export default function Delegate(props: {
           }
         />
       </SkStack>
-
-      <ErrorTile errorMsg={props.errorMsg} setErrorMsg={props.setErrorMsg} className="mt-2.5" />
 
       {loading ? (
         <Button

--- a/src/components/delegation/Delegate.tsx
+++ b/src/components/delegation/Delegate.tsx
@@ -66,7 +66,7 @@ export default function Delegate(props: {
 
   useEffect(() => {
     if (props.loaded && !props.delegationTypeAvailable && props.address) {
-      notify.permanentError('Delegation type is not available')
+      notify.permanentError('Delegation type is not available', undefined, false)
     }
   }, [props.loaded, props.delegationTypeAvailable, props.address])
 
@@ -89,7 +89,7 @@ export default function Delegate(props: {
   async function stake() {
     setLoading(true)
     if (props.validator === undefined) {
-      notify.permanentError('Validator not found')
+      notify.permanentError('Validator not found', undefined, false)
       setLoading(false)
       return
     }

--- a/src/components/delegation/Delegations.tsx
+++ b/src/components/delegation/Delegations.tsx
@@ -34,8 +34,6 @@ export default function Delegations(props: {
   validators: types.st.IValidator[]
   retrieveRewards: (rewardInfo: types.st.IRewardInfo) => Promise<void>
   loading: types.st.IRewardInfo | types.st.IDelegationInfo | false
-  setErrorMsg: (errorMsg: string | undefined) => void
-  errorMsg: string | undefined
   unstake: (delegationInfo: types.st.IDelegationInfo) => Promise<void>
   cancelRequest: (delegationInfo: types.st.IDelegationInfo) => Promise<void>
   address: types.AddressType | undefined

--- a/src/core/delegation/stakingActions.ts
+++ b/src/core/delegation/stakingActions.ts
@@ -26,7 +26,6 @@ import { sendTransaction, contracts } from '@skalenetwork/metaport'
 import { type types, notify } from '@/core'
 export type LoadingState = types.st.IRewardInfo | types.st.IDelegationInfo | false
 export type SetLoadingFn = (state: LoadingState) => void
-export type SetErrorFn = (msg: string | undefined) => void
 export type PostActionFn = () => Promise<void>
 
 export interface StakingActionProps {
@@ -35,7 +34,6 @@ export interface StakingActionProps {
   skaleNetwork: types.SkaleNetwork
   getMainnetSigner: () => Promise<Signer>
   setLoading: SetLoadingFn
-  setErrorMsg: SetErrorFn
   postAction: PostActionFn
 }
 
@@ -54,7 +52,6 @@ async function processTx({
 }) {
   if (!props.sc || !props.address) return
 
-  props.setErrorMsg(undefined)
   const toastId = notify.loading(`Processing ${txName}...`)
   try {
     const signer = await props.getMainnetSigner()
@@ -71,7 +68,6 @@ async function processTx({
     await props.postAction()
   } catch (err: any) {
     const errMsg = err.message || 'Transaction failed'
-    props.setErrorMsg(errMsg)
     notify.permanentError(errMsg, toastId)
   } finally {
     props.setLoading(false)

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -24,7 +24,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useParams } from 'react-router-dom'
-import { type types, metadata, units, constants } from '@/core'
+import { type types, metadata, units, constants, notify } from '@/core'
 
 import { explorer, MetaportCore, SkPaper, Tile } from '@skalenetwork/metaport'
 
@@ -51,7 +51,6 @@ import { getRecentApps, isNewApp, isTrending, isFeatured } from '../core/ecosyst
 
 import SocialButtons from '../components/ecosystem/Socials'
 import CategoriesChips from '../components/ecosystem/CategoriesChips'
-import ErrorTile from '../components/ErrorTile'
 import { ChipNew, ChipPreTge, ChipTrending, ChipFeatured } from '../components/Chip'
 import AppScreenshots from '../components/ecosystem/AppScreenshots'
 import RecommendedApps from '../components/ecosystem/RecommendedApps'
@@ -83,22 +82,18 @@ export default function App(props: {
 
   chain = metadata.findChainName(props.chainsMeta, chain ?? '')
   const chainMeta = props.chainsMeta[chain]
-  if (!chainMeta)
-    return (
-      <Container maxWidth="md">
-        <ErrorTile errorMsg={`No such chain: ${chain}`} />
-      </Container>
-    )
+  if (!chainMeta) {
+    notify.permanentError(`No such chain: ${chain}`)
+    return null
+  }
 
   const appAlias = metadata.getAlias(network, props.chainsMeta, chain, app)
   const appMeta = chainMeta.apps?.[app]
 
-  if (!appMeta)
-    return (
-      <Container maxWidth="md">
-        <ErrorTile errorMsg={`No such app: ${app}`} />
-      </Container>
-    )
+  if (!appMeta) {
+    notify.permanentError(`No such app: ${app}`)
+    return null
+  }
 
   const appDescription = appMeta.description ?? 'No description'
 

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -83,7 +83,7 @@ export default function App(props: {
   chain = metadata.findChainName(props.chainsMeta, chain ?? '')
   const chainMeta = props.chainsMeta[chain]
   if (!chainMeta) {
-    notify.permanentError(`No such chain: ${chain}`)
+    notify.permanentError(`No such chain: ${chain}`, undefined, false)
     return null
   }
 
@@ -91,7 +91,7 @@ export default function App(props: {
   const appMeta = chainMeta.apps?.[app]
 
   if (!appMeta) {
-    notify.permanentError(`No such app: ${app}`)
+    notify.permanentError(`No such app: ${app}`, undefined, false)
     return null
   }
 

--- a/src/pages/Chain.tsx
+++ b/src/pages/Chain.tsx
@@ -28,10 +28,9 @@ import CircularProgress from '@mui/material/CircularProgress'
 import Container from '@mui/material/Container'
 
 import { type MetaportCore } from '@skalenetwork/metaport'
-import { type types, metadata } from '@/core'
+import { type types, metadata, notify } from '@/core'
 
 import SchainDetails from '../components/SchainDetails'
-import ErrorTile from '../components/ErrorTile'
 
 export default function Chain(props: {
   loadData: () => Promise<void>
@@ -64,6 +63,12 @@ export default function Chain(props: {
     }
   }, [props.metrics])
 
+  useEffect(() => {
+    if (props.schains.length > 0 && (chain === undefined || chain === null)) {
+      notify.permanentError(`No such chain: ${chainName}`)
+    }
+  }, [chainName, props.schains])
+
   if (props.schains.length === 0) {
     return (
       <div className="fullscreen-msg">
@@ -82,11 +87,7 @@ export default function Chain(props: {
   }
 
   if (chain === undefined || chain === null) {
-    return (
-      <Container maxWidth="md">
-        <ErrorTile errorMsg={`No such chain: ${chainName}`} />
-      </Container>
-    )
+    return null
   }
 
   return (

--- a/src/pages/Chain.tsx
+++ b/src/pages/Chain.tsx
@@ -65,7 +65,7 @@ export default function Chain(props: {
 
   useEffect(() => {
     if (props.schains.length > 0 && (chain === undefined || chain === null)) {
-      notify.permanentError(`No such chain: ${chainName}`)
+      notify.permanentError(`No such chain: ${chainName}`, undefined, false)
     }
   }, [chainName, props.schains])
 

--- a/src/pages/Credits.tsx
+++ b/src/pages/Credits.tsx
@@ -43,7 +43,6 @@ import ConnectWallet from '../components/ConnectWallet'
 import ChainCreditsTile from '../components/credits/ChainCreditsTile'
 import CreditsPaymentTile from '../components/credits/CreditsPaymentTile'
 import { getCreditStation, getTokenPrices } from '../core/credit-station'
-import ErrorTile from '../components/ErrorTile'
 import { History, HistoryIcon, Link2 } from 'lucide-react'
 
 interface CreditsProps {
@@ -60,7 +59,6 @@ const Credits: React.FC<CreditsProps> = ({ mpc, address, loadData, schains, chai
   const [tokenBalances, setTokenBalances] = useState<types.mp.TokenBalancesMap>()
   const [tokenContracts, setTokenContracts] = useState<types.mp.TokenContractsMap>({})
   const [ledgerContracts, setLedgerContracts] = useState<{ [schainName: string]: Contract }>({})
-  const [errorMsg, setErrorMsg] = useState<string | undefined>(undefined)
   const [payments, setPayments] = useState<cs.Payment[]>([])
 
   async function loadPayments() {
@@ -163,7 +161,6 @@ const Credits: React.FC<CreditsProps> = ({ mpc, address, loadData, schains, chai
           </div>
           <SkPageInfoIcon meta_tag={META_TAGS.credits} />
         </div>
-        <ErrorTile errorMsg={errorMsg} className="mb-2.5" />
         <SkPaper gray className="mt-5">
           <AccordionSection
             expandedByDefault={true}
@@ -181,7 +178,6 @@ const Credits: React.FC<CreditsProps> = ({ mpc, address, loadData, schains, chai
                   creditStation={creditStation}
                   tokenPrices={tokenPrices}
                   tokenBalances={tokenBalances}
-                  setErrorMsg={setErrorMsg}
                 />
               ))}
             </Collapse>
@@ -210,7 +206,6 @@ const Credits: React.FC<CreditsProps> = ({ mpc, address, loadData, schains, chai
                   chainsMeta={chainsMeta}
                   ledgerContract={ledgerContracts[payment.schainName]}
                   creditStation={creditStation}
-                  setErrorMsg={setErrorMsg}
                 />
               ))}
             </Collapse>

--- a/src/pages/StakeAmount.tsx
+++ b/src/pages/StakeAmount.tsx
@@ -101,7 +101,7 @@ export default function StakeAmount(props: {
   }
 
   useEffect(() => {
-    if (validatorId === -1) notify.permanentError('Validator ID is not found')
+    if (validatorId === -1) notify.permanentError('Validator ID is not found', undefined, false)
   }, [validatorId])
 
   if (validatorId === -1) {

--- a/src/pages/StakeAmount.tsx
+++ b/src/pages/StakeAmount.tsx
@@ -26,6 +26,7 @@ import { type Signer } from 'ethers'
 import { useParams } from 'react-router-dom'
 import { type MetaportCore, SkPaper, contracts } from '@skalenetwork/metaport'
 import { types } from '@/core'
+import { notify } from '@/core'
 
 import Container from '@mui/material/Container'
 import { ChevronLeft, CircleDollarSign, HandCoins, UserRoundSearch } from 'lucide-react'
@@ -37,7 +38,6 @@ import Delegate from '../components/delegation/Delegate'
 import Breadcrumbs from '../components/Breadcrumbs'
 import ConnectWallet from '../components/ConnectWallet'
 
-import ErrorTile from '../components/ErrorTile'
 import Headline from '../components/Headline'
 import { isDelegationTypeAvailable, isLoaded } from '../core/delegation/staking'
 import { getDelegationTypeAlias } from '../core/delegation'
@@ -59,7 +59,6 @@ export default function StakeAmount(props: {
   const [currentValidator, setCurrentValidator] = useState<types.st.IValidator | undefined>(
     undefined
   )
-  const [errorMsg, setErrorMsg] = useState<string | undefined>()
 
   const loaded = isLoaded(props.si)
   const available = isDelegationTypeAvailable(props.si, delegationType)
@@ -101,8 +100,12 @@ export default function StakeAmount(props: {
     }
   }
 
+  useEffect(() => {
+    if (validatorId === -1) notify.permanentError('Validator ID is not found')
+  }, [validatorId])
+
   if (validatorId === -1) {
-    return <ErrorTile errorMsg="Validator ID is not found" setErrorMsg={setErrorMsg} />
+    return null
   }
 
   return (
@@ -160,8 +163,6 @@ export default function StakeAmount(props: {
             address={props.address}
             si={props.si}
             delegationType={delegationType}
-            errorMsg={errorMsg}
-            setErrorMsg={setErrorMsg}
             loaded={loaded}
             delegationTypeAvailable={available}
             getMainnetSigner={props.getMainnetSigner}

--- a/src/pages/Staking.tsx
+++ b/src/pages/Staking.tsx
@@ -27,7 +27,7 @@ import { Link } from 'react-router-dom'
 import { type Signer, isAddress } from 'ethers'
 import { useCallback, useEffect, useState } from 'react'
 import { SkPaper, contracts, type MetaportCore } from '@skalenetwork/metaport'
-import { types } from '@/core'
+import { types, notify } from '@/core'
 
 import Container from '@mui/material/Container'
 import Stack from '@mui/material/Stack'
@@ -50,7 +50,6 @@ import {
 } from '../core/delegation/stakingActions'
 
 import { BALANCE_UPDATE_INTERVAL_MS } from '../core/constants'
-import ErrorTile from '../components/ErrorTile'
 import ConnectWallet from '../components/ConnectWallet'
 import Headline from '../components/Headline'
 import Message from '../components/Message'
@@ -69,7 +68,6 @@ export default function Staking(props: {
   getMainnetSigner: () => Promise<Signer>
 }) {
   const [loading, setLoading] = useState<LoadingState>(false)
-  const [errorMsg, setErrorMsg] = useState<string | undefined>()
   const [customRewardAddress, setCustomRewardAddress] = useState<types.AddressType | undefined>(
     props.address
   )
@@ -97,7 +95,6 @@ export default function Staking(props: {
       skaleNetwork: props.mpc.config.skaleNetwork,
       getMainnetSigner: props.getMainnetSigner,
       setLoading,
-      setErrorMsg,
       postAction: props.loadStakingInfo
     }),
     [
@@ -118,7 +115,6 @@ export default function Staking(props: {
   async function handleRetrieveRewards(rewardInfo: types.st.IRewardInfo) {
     if (!isAddress(customRewardAddress)) {
       notify.permanentError('Invalid address')
-      setErrorMsg('Invalid address')
       setLoading(false)
       return
     }
@@ -258,8 +254,6 @@ export default function Staking(props: {
         </SkPaper>
       </Collapse>
 
-      <ErrorTile errorMsg={errorMsg} setErrorMsg={setErrorMsg} className="mt-5" />
-
       <SkPaper gray className="mt-5">
         <Collapse in={props.address !== undefined}>
           <Delegations
@@ -267,8 +261,6 @@ export default function Staking(props: {
             si={props.si}
             retrieveRewards={handleRetrieveRewards}
             loading={loading}
-            setErrorMsg={setErrorMsg}
-            errorMsg={errorMsg}
             unstake={handleUnstake}
             cancelRequest={handleCancelRequest}
             address={props.address}

--- a/src/pages/Staking.tsx
+++ b/src/pages/Staking.tsx
@@ -114,7 +114,7 @@ export default function Staking(props: {
 
   async function handleRetrieveRewards(rewardInfo: types.st.IRewardInfo) {
     if (!isAddress(customRewardAddress)) {
-      notify.permanentError('Invalid address')
+      notify.permanentError('Invalid address', undefined, false)
       setLoading(false)
       return
     }

--- a/src/pages/Validator.tsx
+++ b/src/pages/Validator.tsx
@@ -49,7 +49,6 @@ import SortToggle from '../components/delegation/SortToggle'
 import ShowMoreButton from '../components/delegation/ShowMoreButton'
 import DelegationTotals from '../components/delegation/DelegationTotals'
 import Message from '../components/Message'
-import ErrorTile from '../components/ErrorTile'
 import ChainRewards from '../components/delegation/ChainRewards'
 import { Building2, Eye, Rows3, UserSearch } from 'lucide-react'
 
@@ -68,7 +67,6 @@ export default function Validator(props: {
   const [visibleItems, setVisibleItems] = useState(ITEMS_PER_PAGE)
 
   const [loading, setLoading] = useState<LoadingState>(false)
-  const [errorMsg, setErrorMsg] = useState<string | undefined>()
 
   const getStakingActionProps = useCallback(
     (): StakingActionProps => ({
@@ -77,7 +75,6 @@ export default function Validator(props: {
       skaleNetwork: props.mpc.config.skaleNetwork,
       getMainnetSigner: props.getMainnetSigner,
       setLoading,
-      setErrorMsg,
       postAction: props.loadValidator
     }),
     [
@@ -233,7 +230,6 @@ export default function Validator(props: {
           chainsMeta={props.chainsMeta}
         />
       )}
-      <ErrorTile errorMsg={errorMsg} setErrorMsg={setErrorMsg} className="mt-5" />
       {props.validator && (
         <SkPaper gray className="mt-5">
           <div>

--- a/src/useSFuel.tsx
+++ b/src/useSFuel.tsx
@@ -124,7 +124,7 @@ export function usesFuel(mpc: MetaportCore) {
 
     if (errorOccurred) {
       log.error('sFuel mining encountered errors on one or more chains')
-      notify.permanentError('sFUEL mining failed on some chains', toastId)
+      notify.permanentError('sFUEL mining failed on some chains', toastId, false)
     } else {
       log.info('sFuel mining completed successfully on all required chains')
       notify.temporarySuccess('sFUEL recharged on all chains', toastId)


### PR DESCRIPTION
This pull request focuses on improving error handling and notification consistency across the application. The main changes include standardizing how error messages are displayed to users by trimming and formatting them, always showing a hint to check the browser console for details, and removing redundant local error state management from many components in favor of global notification methods. Additionally, the code now consistently extracts and displays only the first sentence of error messages in UI components, leading to a cleaner and more user-friendly experience.

**Error handling and notification improvements:**

* Updated `notify.permanentError` and `notify.temporaryError` in `notify.ts` to trim and format error messages, and to always include a "Check browser console for details" description. (`packages/core/src/notify.ts` [packages/core/src/notify.tsR36-R45](diffhunk://#diff-252a7da0c1fd7d05a682ebe1cb34aa506b1e7da306b5c683bc750969dc66b239R36-R45))
* In `MetaportStore.ts`, error headlines are now trimmed to the first sentence and capitalized before being sent to notifications. (`packages/metaport/src/store/MetaportStore.ts` [packages/metaport/src/store/MetaportStore.tsR205](diffhunk://#diff-41bbf0557c40cce7ed4b5290469dfb85315814da887d3036679e008f71d22e71R205))
* UI error messages in `ErrorMessage.tsx` now only show the first sentence of the error, using a new `extractFirstSentence` helper. (`packages/metaport/src/components/ErrorMessage.tsx` [[1]](diffhunk://#diff-39a59e1c580beed92102900ddd58207fef3bfa2efdfae6c9f15b09a5ef87bd16R46) [[2]](diffhunk://#diff-39a59e1c580beed92102900ddd58207fef3bfa2efdfae6c9f15b09a5ef87bd16L73-R74) [[3]](diffhunk://#diff-39a59e1c580beed92102900ddd58207fef3bfa2efdfae6c9f15b09a5ef87bd16L136-R137)

**Refactoring and code simplification:**

* Removed local error state (`errorMsg` and `setErrorMsg`) from multiple components (`MonthSelector`, `Paymaster`, `Topup`, `ChainCreditsTile`, `CreditStationStatusTile`, `CreditsPaymentTile`, `TokenAdminTile`, `TokensAdmin`), relying instead on global notification methods for error reporting. [[1]](diffhunk://#diff-c5e6f3bad3e507ce407c8467d2d285e99db234eef0c06e205d652cb6d9cb8f15L38) [[2]](diffhunk://#diff-c5e6f3bad3e507ce407c8467d2d285e99db234eef0c06e205d652cb6d9cb8f15L103-L116) [[3]](diffhunk://#diff-58fc4cbd669aac312c8fbe8e779be85c8d7220f5b0e2c1de3c636ca9c31659a8L60) [[4]](diffhunk://#diff-58fc4cbd669aac312c8fbe8e779be85c8d7220f5b0e2c1de3c636ca9c31659a8L108-L114) [[5]](diffhunk://#diff-58fc4cbd669aac312c8fbe8e779be85c8d7220f5b0e2c1de3c636ca9c31659a8L142) [[6]](diffhunk://#diff-58fc4cbd669aac312c8fbe8e779be85c8d7220f5b0e2c1de3c636ca9c31659a8L201-L202) [[7]](diffhunk://#diff-bca5db7309fed5de349e24488725cd3ed5f7de1e57f3d647af48ae06e4aa7fa1L35) [[8]](diffhunk://#diff-bca5db7309fed5de349e24488725cd3ed5f7de1e57f3d647af48ae06e4aa7fa1L47-L48) [[9]](diffhunk://#diff-bca5db7309fed5de349e24488725cd3ed5f7de1e57f3d647af48ae06e4aa7fa1L83) [[10]](diffhunk://#diff-bca5db7309fed5de349e24488725cd3ed5f7de1e57f3d647af48ae06e4aa7fa1L115) [[11]](diffhunk://#diff-a362966732073615542c48b878bd96ca2e12fd2f8d9b563731d6b5fedad60376L71) [[12]](diffhunk://#diff-a362966732073615542c48b878bd96ca2e12fd2f8d9b563731d6b5fedad60376L80-R79) [[13]](diffhunk://#diff-a362966732073615542c48b878bd96ca2e12fd2f8d9b563731d6b5fedad60376L151-L157) [[14]](diffhunk://#diff-a362966732073615542c48b878bd96ca2e12fd2f8d9b563731d6b5fedad60376L194) [[15]](diffhunk://#diff-11b661fd997484253c5e0e266082315a395018c3c3ebb1ae3f3bf84df0c61e9aL41-R45) [[16]](diffhunk://#diff-11b661fd997484253c5e0e266082315a395018c3c3ebb1ae3f3bf84df0c61e9aL74) [[17]](diffhunk://#diff-11b661fd997484253c5e0e266082315a395018c3c3ebb1ae3f3bf84df0c61e9aL96) [[18]](diffhunk://#diff-18c6b18572d158e75019bbe5ee2e369b0b63537c73a41990d36f88ebde26160bL60) [[19]](diffhunk://#diff-18c6b18572d158e75019bbe5ee2e369b0b63537c73a41990d36f88ebde26160bL69-R68) [[20]](diffhunk://#diff-18c6b18572d158e75019bbe5ee2e369b0b63537c73a41990d36f88ebde26160bL117) [[21]](diffhunk://#diff-18c6b18572d158e75019bbe5ee2e369b0b63537c73a41990d36f88ebde26160bL139) [[22]](diffhunk://#diff-bf44adcef6bf75cf423b474b2119002b006aff416e62b1012d2a9f2be71c042dL56) [[23]](diffhunk://#diff-1278eb8024429f65001af00a5df81bab24d8f6c13eedd403b1bdcd9920650172L34) [[24]](diffhunk://#diff-1278eb8024429f65001af00a5df81bab24d8f6c13eedd403b1bdcd9920650172L56) [[25]](diffhunk://#diff-1278eb8024429f65001af00a5df81bab24d8f6c13eedd403b1bdcd9920650172L88) [[26]](diffhunk://#diff-1278eb8024429f65001af00a5df81bab24d8f6c13eedd403b1bdcd9920650172L99) [[27]](diffhunk://#diff-1278eb8024429f65001af00a5df81bab24d8f6c13eedd403b1bdcd9920650172L121) [[28]](diffhunk://#diff-1278eb8024429f65001af00a5df81bab24d8f6c13eedd403b1bdcd9920650172L160)

These changes make error reporting more consistent and reduce code duplication by centralizing error handling logic.