### PR TITLE
Add trails tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ tools/*
 
 
 packages/**/dist
+
+docs/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "skale-network"]
 	path = skale-network
 	url = https://github.com/skalenetwork/skale-network.git
+	branch = update-base-sandbox-metadata
 [submodule "helper-scripts"]
 	path = helper-scripts
 	url = https://github.com/skalenetwork/helper-scripts.git

--- a/config/base/index.ts
+++ b/config/base/index.ts
@@ -72,6 +72,30 @@ export const METAPORT_CONFIG: types.mp.Config = {
               bridge: 'trails'
             }
           }
+        },
+        usdt: {
+          address: '0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        wbtc: {
+          address: '0x50b7545627a5162F82A992c33b87aDc75187B218',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        weth: {
+          address: '0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
         }
       }
     },
@@ -79,6 +103,30 @@ export const METAPORT_CONFIG: types.mp.Config = {
       erc20: {
         usdc: {
           address: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        usdt: {
+          address: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        wbtc: {
+          address: '0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        weth: {
+          address: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619',
           chains: {
             'winged-bubbly-grumium': {
               bridge: 'trails'
@@ -108,6 +156,30 @@ export const METAPORT_CONFIG: types.mp.Config = {
               bridge: 'trails'
             }
           }
+        },
+        usdt: {
+          address: '0x4ECaBa5870353805a9F068101A40E0f32ed605C6',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        wbtc: {
+          address: '0x8e5bBbb09Ed1ebdE8674Cda39A0c169401db4252',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        weth: {
+          address: '0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
         }
       }
     },
@@ -120,6 +192,30 @@ export const METAPORT_CONFIG: types.mp.Config = {
               bridge: 'trails'
             }
           }
+        },
+        usdt: {
+          address: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        wbtc: {
+          address: '0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        weth: {
+          address: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
         }
       }
     },
@@ -127,6 +223,30 @@ export const METAPORT_CONFIG: types.mp.Config = {
       erc20: {
         usdc: {
           address: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        usdt: {
+          address: '0x94b008aA00579c1307B0EF2c499aD98a8ce58e58',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        wbtc: {
+          address: '0x68f180fcCe6836688e9084f035309E29Bf0A2095',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        weth: {
+          address: '0x4200000000000000000000000000000000000006',
           chains: {
             'winged-bubbly-grumium': {
               bridge: 'trails'
@@ -193,6 +313,21 @@ export const METAPORT_CONFIG: types.mp.Config = {
           chains: {
             mainnet: {
               clone: true
+            },
+            'ext-arbitrum': {
+               bridge: 'trails'
+              },
+            'ext-op-mainnet': {
+              bridge: 'trails'
+            },
+            'ext-avalanche': {
+              bridge: 'trails'
+            },
+            'ext-polygon': {
+              bridge: 'trails'
+            },
+            'ext-gnosis': {
+              bridge: 'trails'
             }
           }
         },
@@ -201,6 +336,21 @@ export const METAPORT_CONFIG: types.mp.Config = {
           chains: {
             mainnet: {
               clone: true
+            },
+            'ext-arbitrum': {
+              bridge: 'trails'
+            },
+            'ext-op-mainnet': {
+              bridge: 'trails'
+            },
+            'ext-avalanche': {
+              bridge: 'trails'
+            },
+            'ext-polygon': {
+              bridge: 'trails'
+            },
+            'ext-gnosis': {
+              bridge: 'trails'
             }
           }
         },
@@ -209,6 +359,21 @@ export const METAPORT_CONFIG: types.mp.Config = {
           chains: {
             mainnet: {
               clone: true
+            },
+            'ext-arbitrum': {
+              bridge: 'trails'
+            },
+            'ext-op-mainnet': {
+              bridge: 'trails'
+            },
+            'ext-avalanche': {
+              bridge: 'trails'
+            },
+            'ext-polygon': {
+              bridge: 'trails'
+            },
+            'ext-gnosis': {
+              bridge: 'trails'
             }
           }
         },

--- a/config/base/index.ts
+++ b/config/base/index.ts
@@ -10,13 +10,15 @@ export const METAPORT_CONFIG: types.mp.Config = {
   chains: [
     'mainnet',
     'winged-bubbly-grumium', // SKALE Base Mainnet
+    'ext-mainnet',
     'ext-arbitrum',
+    'ext-arbitrum-nova',
     'ext-op-mainnet',
     'ext-avalanche',
     'ext-bsc',
     'ext-polygon',
     'ext-monad',
-    'ext-gnosis',
+    'ext-gnosis'
   ],
   tokens: {
     eth: {
@@ -54,7 +56,33 @@ export const METAPORT_CONFIG: types.mp.Config = {
     'ext-bsc': {
       erc20: {
         usdc: {
-          address: '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d', // 18 decimals on bsc - todo: handle
+          address: '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d',
+          decimals: 18,
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        usdt: {
+          address: '0x55d398326f99059fF775485246999027B3197955',
+          decimals: 18,
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        weth: {
+          address: '0x2170Ed0880ac9A755fd29B2688956BD959F933F8',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        wbtc: {
+          address: '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c',
           chains: {
             'winged-bubbly-grumium': {
               bridge: 'trails'
@@ -139,6 +167,14 @@ export const METAPORT_CONFIG: types.mp.Config = {
       erc20: {
         usdc: {
           address: '0x754704Bc059F8C67012fEd69BC8A327a5aafb603',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        wbtc: {
+          address: '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c',
           chains: {
             'winged-bubbly-grumium': {
               bridge: 'trails'
@@ -255,6 +291,62 @@ export const METAPORT_CONFIG: types.mp.Config = {
         }
       }
     },
+    'ext-mainnet': {
+      erc20: {
+        usdc: {
+          address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        usdt: {
+          address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        weth: {
+          address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        wbtc: {
+          address: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        }
+      }
+    },
+    'ext-arbitrum-nova': {
+      erc20: {
+        usdc: {
+          address: '0x750ba8b76187092B0D1E87E28daaf484d1b5273b',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        },
+        weth: {
+          address: '0x722E8BdD2ce80A4422E880164f2079488e115365',
+          chains: {
+            'winged-bubbly-grumium': {
+              bridge: 'trails'
+            }
+          }
+        }
+      }
+    },
     mainnet: {
       eth: {
         eth: {
@@ -314,10 +406,16 @@ export const METAPORT_CONFIG: types.mp.Config = {
             mainnet: {
               clone: true
             },
+            'ext-mainnet': {
+              bridge: 'trails'
+            },
             'ext-arbitrum': {
-               bridge: 'trails'
-              },
+              bridge: 'trails'
+            },
             'ext-op-mainnet': {
+              bridge: 'trails'
+            },
+            'ext-bsc': {
               bridge: 'trails'
             },
             'ext-avalanche': {
@@ -337,16 +435,25 @@ export const METAPORT_CONFIG: types.mp.Config = {
             mainnet: {
               clone: true
             },
+            'ext-mainnet': {
+              bridge: 'trails'
+            },
             'ext-arbitrum': {
               bridge: 'trails'
             },
             'ext-op-mainnet': {
               bridge: 'trails'
             },
+            'ext-bsc': {
+              bridge: 'trails'
+            },
             'ext-avalanche': {
               bridge: 'trails'
             },
             'ext-polygon': {
+              bridge: 'trails'
+            },
+            'ext-monad': {
               bridge: 'trails'
             },
             'ext-gnosis': {
@@ -360,10 +467,19 @@ export const METAPORT_CONFIG: types.mp.Config = {
             mainnet: {
               clone: true
             },
+            'ext-mainnet': {
+              bridge: 'trails'
+            },
             'ext-arbitrum': {
               bridge: 'trails'
             },
+            'ext-arbitrum-nova': {
+              bridge: 'trails'
+            },
             'ext-op-mainnet': {
+              bridge: 'trails'
+            },
+            'ext-bsc': {
               bridge: 'trails'
             },
             'ext-avalanche': {
@@ -391,7 +507,13 @@ export const METAPORT_CONFIG: types.mp.Config = {
             mainnet: {
               clone: true
             },
+            'ext-mainnet': {
+              bridge: 'trails'
+            },
             'ext-arbitrum': {
+              bridge: 'trails'
+            },
+            'ext-arbitrum-nova': {
               bridge: 'trails'
             },
             'ext-op-mainnet': {

--- a/packages/core/src/dataclasses/TokenData.ts
+++ b/packages/core/src/dataclasses/TokenData.ts
@@ -40,11 +40,14 @@ export class TokenData {
     tokenKeyname: string,
     metadata: TokenMetadata,
     connections: ConnectedChainMap,
-    chain: string
+    chain: string,
+    decimalsOverride?: number
   ) {
     this.address = address
-    this.meta = metadata
-    this.meta.decimals = this.meta.decimals ? this.meta.decimals : DEFAULT_ERC20_DECIMALS
+    this.meta = {
+      ...metadata,
+      decimals: decimalsOverride ?? metadata.decimals ?? DEFAULT_ERC20_DECIMALS
+    }
     this.connections = connections
     this.type = type
     this.keyname = tokenKeyname

--- a/packages/core/src/types/metaport/Tokens.ts
+++ b/packages/core/src/types/metaport/Tokens.ts
@@ -29,6 +29,7 @@ export interface EthToken {
 
 export interface Token {
   address?: AddressType
+  decimals?: number
   chains: ConnectedChainMap
 }
 

--- a/packages/metaport/src/components/TrailsIntentTracker.tsx
+++ b/packages/metaport/src/components/TrailsIntentTracker.tsx
@@ -97,7 +97,7 @@ function StepIcon({ status }: { status: TransactionStatus }) {
 
 function TxStepRow({ step, skaleNetwork }: { step: TxStep; skaleNetwork: types.SkaleNetwork }) {
   const chainsMeta = CHAINS_META[skaleNetwork]
-  const chainName = step.chainName ?? chainIdToName(step.chainId)
+  const chainName = step.chainName ?? chainIdToName(step.chainId, skaleNetwork)
   const displayName = metadata.getAlias(skaleNetwork, chainsMeta, chainName)
   const url = step.txnHash
     ? getTxUrl(chainsMeta[chainName], chainName, skaleNetwork, step.txnHash)

--- a/packages/metaport/src/components/TrailsQuoteCard.tsx
+++ b/packages/metaport/src/components/TrailsQuoteCard.tsx
@@ -29,7 +29,7 @@ import SkPaper from './SkPaper'
 import TokenIcon from './TokenIcon'
 import trailsLogo from '../assets/trails_logo.svg'
 import { useMetaportStore } from '../store/MetaportStore'
-import { type QuoteIntentResponse } from '../core/trails'
+import { humanizeTrailsError, type QuoteIntentResponse } from '../core/trails'
 
 function formatAmount(amount: bigint, decimals: number): string {
   const divisor = 10n ** BigInt(decimals)
@@ -70,10 +70,6 @@ export default function TrailsQuoteCard(props: {
               <img src={trailsLogo} alt="Trails" className="h-5 rounded-sm" />
             </a>
           </div>
-          <div className="inline-flex items-center gap-1.5 rounded-full border-amber-500/20 bg-amber-500/10 px-2.5 py-0.5 text-amber-600 dark:text-amber-400">
-            <AlertTriangle size={12} />
-            <span className="text-xs font-medium ">Unable to get a quote from Trails</span>
-          </div>
         </div>
 
         <div className="flex items-baseline justify-between pt-2">
@@ -97,6 +93,11 @@ export default function TrailsQuoteCard(props: {
               <p className="text-xl font-bold text-foreground m-0">N/A</p>
             </div>
           </div>
+        </div>
+
+        <div className="mt-3 flex w-full items-center gap-2 rounded-full bg-red-500/10 px-3 py-2 text-red-600 dark:text-red-400">
+          <AlertTriangle size={16} className="shrink-0" />
+          <span className="text-xs font-medium leading-tight">{humanizeTrailsError(props.error)}</span>
         </div>
       </SkPaper>
     )

--- a/packages/metaport/src/core/actions/trails.ts
+++ b/packages/metaport/src/core/actions/trails.ts
@@ -37,6 +37,7 @@ import {
   encodeDepositERC20Direct,
   wrapWithTrailsRouter,
   getTrailsRouterAddress,
+  extractTrailsErrorMessage,
   TRAILS_ROUTER_PLACEHOLDER_AMOUNT,
   type QuoteIntentResponse
 } from '../trails'
@@ -163,7 +164,7 @@ export class TransferTrailsExt2M extends Action {
     } catch (err) {
       log.error('TransferTrailsExt2M:preAction - quote failed', err)
       this.trailsQuote = null
-      this.trailsQuoteError = err instanceof Error ? err.message : String(err)
+      this.trailsQuoteError = extractTrailsErrorMessage(err)
     }
   }
 }
@@ -264,7 +265,7 @@ export class TransferTrailsExt2S extends Action {
     } catch (err) {
       log.error('TransferTrailsExt2S:preAction - quote failed', err)
       this.trailsQuote = null
-      this.trailsQuoteError = err instanceof Error ? err.message : String(err)
+      this.trailsQuoteError = extractTrailsErrorMessage(err)
     }
   }
 }
@@ -343,7 +344,7 @@ export class TransferTrailsM2Ext extends Action {
     } catch (err) {
       log.error('TransferTrailsM2Ext:preAction - quote failed', err)
       this.trailsQuote = null
-      this.trailsQuoteError = err instanceof Error ? err.message : String(err)
+      this.trailsQuoteError = extractTrailsErrorMessage(err)
     }
   }
 }

--- a/packages/metaport/src/core/metaport.ts
+++ b/packages/metaport/src/core/metaport.ts
@@ -48,7 +48,8 @@ export const createTokenData = (
     tokenKeyname,
     config.tokens[tokenKeyname],
     configToken.chains,
-    chainName
+    chainName,
+    configToken.decimals
   )
 }
 

--- a/packages/metaport/src/core/network.ts
+++ b/packages/metaport/src/core/network.ts
@@ -33,6 +33,7 @@ import {
   base,
   baseSepolia,
   arbitrum,
+  arbitrumNova,
   polygon,
   optimism,
   avalanche,
@@ -50,7 +51,8 @@ const log = new Logger<ILogObj>({ name: 'metaport:core:network' })
 export const EXT_PREFIX = 'ext-'
 
 export const EXT_CHAIN_RPC_OVERRIDES: Record<string, string> = {
-  polygon: 'https://polygon-bor-rpc.publicnode.com'
+  polygon: 'https://polygon-bor-rpc.publicnode.com',
+  mainnet: 'https://ethereum-rpc.publicnode.com'
 }
 
 export function extChainRpcUrl(chainName: string): string {
@@ -62,12 +64,14 @@ export function extChainRpcUrl(chainName: string): string {
 
 export const EXT_CHAINS: Record<string, Chain> = {
   arbitrum,
+  'arbitrum-nova': arbitrumNova,
   polygon,
   'op-mainnet': optimism,
   avalanche,
   bsc,
   monad,
-  gnosis
+  gnosis,
+  mainnet
 }
 
 export function isExtChain(chainName: string): boolean {
@@ -102,15 +106,17 @@ export function isMainnetChainId(
   return Number(chainId) === NETWORK_MAINNET_CHAINS[skaleNetwork].id
 }
 
-const _chainIdToName: Record<number, string> = (() => {
+const _chainIdToExtName: Record<number, string> = (() => {
   const map: Record<number, string> = {}
-  for (const chain of MAINNET_CHAINS) map[chain.id] = constants.MAINNET_CHAIN_NAME
   for (const [key, chain] of Object.entries(EXT_CHAINS)) map[chain.id] = `${EXT_PREFIX}${key}`
   return map
 })()
 
-export function chainIdToName(chainId: number): string {
-  return _chainIdToName[chainId] ?? constants.MAINNET_CHAIN_NAME
+export function chainIdToName(chainId: number, skaleNetwork: types.SkaleNetwork): string {
+  if (NETWORK_MAINNET_CHAINS[skaleNetwork].id === chainId) {
+    return constants.MAINNET_CHAIN_NAME
+  }
+  return _chainIdToExtName[chainId] ?? constants.MAINNET_CHAIN_NAME
 }
 
 export function mainnetProvider(mainnetEndpoint: string): Provider {

--- a/packages/metaport/src/core/trails.ts
+++ b/packages/metaport/src/core/trails.ts
@@ -123,6 +123,33 @@ function getTrailsApi(): TrailsApi {
   return trailsApi
 }
 
+export function extractTrailsErrorMessage(err: unknown): string {
+  if (!(err instanceof Error)) return String(err)
+  let current: unknown = err
+  let last = err.message
+  // Walk the cause chain — webrpc wraps the useful detail in err.cause
+  for (let i = 0; i < 5 && current instanceof Error; i++) {
+    last = current.message || last
+    current = (current as Error).cause
+  }
+  if (typeof current === 'string') return current
+  return last
+}
+
+export function humanizeTrailsError(raw: string | null | undefined): string {
+  if (!raw) return 'Unable to get a quote from Trails.'
+  if (/no routes found/i.test(raw)) {
+    return "Trails doesn't have a route for this token pair right now. Try a different chain or token."
+  }
+  if (/insufficient origin amount/i.test(raw)) {
+    return 'The amount is too small to cover gas + bridge fees. Try a larger amount.'
+  }
+  if (/rate limit|429/i.test(raw)) {
+    return 'Trails is rate-limiting requests. Wait a moment and try again.'
+  }
+  return 'Unable to get a quote from Trails. Try a larger amount or a different route.'
+}
+
 let trailsRouterAddressCache: string | null = null
 
 export async function getTrailsRouterAddress(): Promise<string> {


### PR DESCRIPTION
This pull request introduces significant enhancements and extensions to the Metaport configuration and core logic, primarily to support additional external chains, standardize token metadata (especially decimals), and improve error handling and user feedback for Trails integration.

**Metaport Configuration and Chain Support:**

* Added support for new external chains: `'ext-mainnet'` and `'ext-arbitrum-nova'` are now included in the list of supported chains in `METAPORT_CONFIG`, and their token configurations have been defined. [[1]](diffhunk://#diff-dd9999714efa6b879d782ee398ff6b7204cfaa1cb8921563ef0d3a65631c6442R13-R21) [[2]](diffhunk://#diff-dd9999714efa6b879d782ee398ff6b7204cfaa1cb8921563ef0d3a65631c6442R267-R346)
* Expanded token bridge mappings: For tokens like USDC, USDT, WETH, and WBTC on multiple chains (BSC, Avalanche, Polygon, etc.), added or completed `address`, `decimals`, and detailed bridge configuration to `'winged-bubbly-grumium'` via Trails. [[1]](diffhunk://#diff-dd9999714efa6b879d782ee398ff6b7204cfaa1cb8921563ef0d3a65631c6442L57-R85) [[2]](diffhunk://#diff-dd9999714efa6b879d782ee398ff6b7204cfaa1cb8921563ef0d3a65631c6442R103-R126) [[3]](diffhunk://#diff-dd9999714efa6b879d782ee398ff6b7204cfaa1cb8921563ef0d3a65631c6442R139-R162) [[4]](diffhunk://#diff-dd9999714efa6b879d782ee398ff6b7204cfaa1cb8921563ef0d3a65631c6442R175-R182) [[5]](diffhunk://#diff-dd9999714efa6b879d782ee398ff6b7204cfaa1cb8921563ef0d3a65631c6442R195-R218) [[6]](diffhunk://#diff-dd9999714efa6b879d782ee398ff6b7204cfaa1cb8921563ef0d3a65631c6442R231-R254) [[7]](diffhunk://#diff-dd9999714efa6b879d782ee398ff6b7204cfaa1cb8921563ef0d3a65631c6442R267-R346)
* Updated bridge routes: Enhanced the mapping of token bridges from `'winged-bubbly-grumium'` to all supported external chains, ensuring each has a `bridge: 'trails'` configuration. [[1]](diffhunk://#diff-dd9999714efa6b879d782ee398ff6b7204cfaa1cb8921563ef0d3a65631c6442R408-R428) [[2]](diffhunk://#diff-dd9999714efa6b879d782ee398ff6b7204cfaa1cb8921563ef0d3a65631c6442R437-R460) [[3]](diffhunk://#diff-dd9999714efa6b879d782ee398ff6b7204cfaa1cb8921563ef0d3a65631c6442R469-R492) [[4]](diffhunk://#diff-dd9999714efa6b879d782ee398ff6b7204cfaa1cb8921563ef0d3a65631c6442R510-R518)

**Token Metadata and Decimals Handling:**

* Standardized token decimals: Added a `decimals` property to token definitions and updated the `TokenData` class and `createTokenData` function to support an optional `decimalsOverride`, ensuring correct handling of token precision across chains. [[1]](diffhunk://#diff-415cd5ef2486e8354370c870728db9ed2122833e0d1d53149a2ff22cd33100abR32) [[2]](diffhunk://#diff-1fb0941e245e0fa43eb893aabbc60277a99fb43b680a3a23d12344a0333bc898L51-R52) [[3]](diffhunk://#diff-dd9999714efa6b879d782ee398ff6b7204cfaa1cb8921563ef0d3a65631c6442L57-R85) [[4]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R4)
* Updated types: Modified the `Token` interface to include the optional `decimals` property.

**Trails Integration and Error Handling:**

* Improved error extraction and display: Replaced generic error messages with `extractTrailsErrorMessage` in Trails-related actions, and updated the UI to display user-friendly error messages using `humanizeTrailsError`. [[1]](diffhunk://#diff-8db6e53ff159456488538133193bb6d13f9dfd8c38489c1b125038761aba5426R40) [[2]](diffhunk://#diff-8db6e53ff159456488538133193bb6d13f9dfd8c38489c1b125038761aba5426L166-R167) [[3]](diffhunk://#diff-8db6e53ff159456488538133193bb6d13f9dfd8c38489c1b125038761aba5426L267-R268) [[4]](diffhunk://#diff-8db6e53ff159456488538133193bb6d13f9dfd8c38489c1b125038761aba5426L346-R347) [[5]](diffhunk://#diff-c18535d4522c148110c7c359271bc66946fa5bc160ee40f3f18b20af113f78d3L32-R32) [[6]](diffhunk://#diff-c18535d4522c148110c7c359271bc66946fa5bc160ee40f3f18b20af113f78d3R97-R101)
* Enhanced error UI: Redesigned the error display in `TrailsQuoteCard` to be more prominent and informative. [[1]](diffhunk://#diff-c18535d4522c148110c7c359271bc66946fa5bc160ee40f3f18b20af113f78d3L73-L76) [[2]](diffhunk://#diff-c18535d4522c148110c7c359271bc66946fa5bc160ee40f3f18b20af113f78d3R97-R101)

**Chain Metadata and Utilities:**

* Added support for new chain metadata: Included `arbitrumNova` and `mainnet` in the external chain metadata and RPC overrides, ensuring proper network connectivity and display names. [[1]](diffhunk://#diff-d9a62e3f43dca098405053fc46adf2f9c158ad95f9546ea9a090797aa1792b4aR36) [[2]](diffhunk://#diff-d9a62e3f43dca098405053fc46adf2f9c158ad95f9546ea9a090797aa1792b4aL53-R55) [[3]](diffhunk://#diff-d9a62e3f43dca098405053fc46adf2f9c158ad95f9546ea9a090797aa1792b4aR67-R74)
* Improved chain name resolution: Updated logic in `TrailsIntentTracker` to correctly resolve and display chain names with the current Skale network context.

**Submodule Update:**

* Updated the `skale-network` submodule to track a specific branch for sandbox metadata updates. (.gitmodules)