### PR TITLE
update payments sorting and naming

### DIFF
--- a/src/components/credits/CreditsPaymentTile.tsx
+++ b/src/components/credits/CreditsPaymentTile.tsx
@@ -85,31 +85,20 @@ const CreditsPaymentTile: React.FC<CreditsPaymentTileProps> = ({
       (symbol) => sourceTokens[symbol].address?.toLowerCase() === payment.tokenAddress.toLowerCase()
     ) || 'unknown'
 
-  const displayPaymentId = cs.getLedgerPaymentId(payment.id)
+  const paymentIdPrefix = source?.displayName?.trim().charAt(0).toUpperCase() ?? ''
+  const displayPaymentId = `${paymentIdPrefix ? `${paymentIdPrefix}-` : ''}${cs.getLedgerPaymentId(payment.id).toString()}`
 
   const credits = payment.value
   const creditsLabel = `${credits} ${credits === 1n ? 'Credit' : 'Credits'}`
 
   const [isFulfilled, setIsFulfilled] = useState<boolean>(false)
-  const [txTimestamp, setTxTimestamp] = useState<number | undefined>(undefined)
   const [loading, setLoading] = useState<boolean>(false)
 
   const { chainId } = useWagmiAccount()
   const { data: walletClient } = useWagmiWalletClient({ chainId })
   const { switchChainAsync } = useWagmiSwitchNetwork()
 
-  useEffect(() => {
-    if (!creditStation || !payment) return
-    const fetchTimestamp = async () => {
-      try {
-        const provider = creditStation.runner?.provider
-        if (!provider) return
-        const block = await provider.getBlock(payment.blockNumber)
-        if (block) setTxTimestamp(block.timestamp)
-      } catch (error) { }
-    }
-    fetchTimestamp()
-  }, [creditStation, payment])
+  const txTimestamp = payment.timestamp || undefined
 
   useEffect(() => {
     if (!ledgerContract) return
@@ -249,7 +238,7 @@ const CreditsPaymentTile: React.FC<CreditsPaymentTileProps> = ({
                 size="md"
                 transparent
                 className="p-0! mr-5 ml-5"
-                value={`ID: ${displayPaymentId.toString()}`}
+                value={displayPaymentId}
                 text="Payment ID"
                 grow
                 ri={true}

--- a/src/core/credit-station.ts
+++ b/src/core/credit-station.ts
@@ -35,6 +35,7 @@ export interface Payment {
   to: `0x${string}`
   tokenAddress: `0x${string}`
   blockNumber: number
+  timestamp: number
   value: bigint
 }
 
@@ -191,7 +192,32 @@ async function getPayments(
     )
     results.push(...chunkPayments)
   }
+  await fillTimestamps(results, creditStation)
   return results
+}
+
+async function fillTimestamps(payments: Payment[], creditStation: Contract): Promise<void> {
+  const provider = creditStation.runner?.provider
+  if (!provider) return
+  const uniqueBlocks = Array.from(new Set(payments.map((p) => p.blockNumber)))
+  const timestamps = new Map<number, number>()
+  const chunkSize = 10
+  for (let i = 0; i < uniqueBlocks.length; i += chunkSize) {
+    const chunk = uniqueBlocks.slice(i, i + chunkSize)
+    await Promise.all(
+      chunk.map(async (blockNumber) => {
+        try {
+          const block = await provider.getBlock(blockNumber)
+          if (block) timestamps.set(blockNumber, block.timestamp)
+        } catch (error) {
+          console.error(`Failed to fetch block ${blockNumber}:`, error)
+        }
+      })
+    )
+  }
+  for (const payment of payments) {
+    payment.timestamp = timestamps.get(payment.blockNumber) ?? 0
+  }
 }
 
 export async function getPaymentsByAddress(
@@ -267,6 +293,7 @@ function toPayment(
     from: data[1],
     to: data[2],
     blockNumber: Number(data[3]),
+    timestamp: 0,
     tokenAddress: data[4],
     value: BigInt(data[5] ?? 0n)
   }

--- a/src/pages/Credits.tsx
+++ b/src/pages/Credits.tsx
@@ -188,7 +188,7 @@ const Credits: React.FC<CreditsProps> = ({ mpc, address, loadData, schains, chai
   }
 
   const sortedPayments = [...payments].sort((a, b) => {
-    if (b.blockNumber !== a.blockNumber) return b.blockNumber - a.blockNumber
+    if (b.timestamp !== a.timestamp) return b.timestamp - a.timestamp
     return Number(b.id - a.id)
   })
 

--- a/src/pages/CreditsAdmin.tsx
+++ b/src/pages/CreditsAdmin.tsx
@@ -126,7 +126,7 @@ const CreditsAdmin: React.FC<CreditsAdminProps> = ({
   }
 
   const sortedPayments = [...allPayments].sort((a, b) => {
-    if (b.blockNumber !== a.blockNumber) return b.blockNumber - a.blockNumber
+    if (b.timestamp !== a.timestamp) return b.timestamp - a.timestamp
     return Number(b.id - a.id)
   })
 

--- a/src/pages/CreditsAdmin.tsx
+++ b/src/pages/CreditsAdmin.tsx
@@ -126,7 +126,7 @@ const CreditsAdmin: React.FC<CreditsAdminProps> = ({
   }
 
   const sortedPayments = [...allPayments].sort((a, b) => {
-    if (b.timestamp !== a.timestamp) return b.timestamp - a.timestamp
+    if (b.blockNumber !== a.blockNumber) return b.blockNumber - a.blockNumber
     return Number(b.id - a.id)
   })
 


### PR DESCRIPTION
This pull request improves how payment timestamps are handled and displayed throughout the credits system. It adds a `timestamp` field to the `Payment` type, ensures timestamps are fetched and filled for all payments, and updates the UI to use these timestamps for sorting and display. Additionally, payment IDs are now prefixed with the source display name for better identification.

**Core data and logic improvements:**

* Added a `timestamp` field to the `Payment` interface and ensured it is set for all payments by fetching block timestamps in batches with the new `fillTimestamps` function. (`src/core/credit-station.ts` [[1]](diffhunk://#diff-ac56e5f9e6e4d50f730c1cd80dc6bd588dd088237ad069320d4c5d247d64e342R38) [[2]](diffhunk://#diff-ac56e5f9e6e4d50f730c1cd80dc6bd588dd088237ad069320d4c5d247d64e342R195-R222) [[3]](diffhunk://#diff-ac56e5f9e6e4d50f730c1cd80dc6bd588dd088237ad069320d4c5d247d64e342R296)
* Updated the logic in `CreditsPaymentTile` to use the `timestamp` directly from the payment data instead of fetching it in a component effect. (`src/components/credits/CreditsPaymentTile.tsx` [src/components/credits/CreditsPaymentTile.tsxL88-R101](diffhunk://#diff-18c6b18572d158e75019bbe5ee2e369b0b63537c73a41990d36f88ebde26160bL88-R101))

**UI and display changes:**

* Payment IDs shown in the UI are now prefixed with the source display name's first character for improved clarity. (`src/components/credits/CreditsPaymentTile.tsx` [[1]](diffhunk://#diff-18c6b18572d158e75019bbe5ee2e369b0b63537c73a41990d36f88ebde26160bL88-R101) [[2]](diffhunk://#diff-18c6b18572d158e75019bbe5ee2e369b0b63537c73a41990d36f88ebde26160bL252-R241)
* Payment sorting in both the user and admin credits pages now uses the `timestamp` field for more accurate chronological ordering. (`src/pages/Credits.tsx` [[1]](diffhunk://#diff-a9aaf2784f134fb15eb57ab8ae78f1c92cfc95cd60973557c9f82586ea7c105aL191-R191) `src/pages/CreditsAdmin.tsx` [[2]](diffhunk://#diff-c7edb10852a881323c35d61919963162cb83a118e59e42c3bd06a06a10bf05c7L129-R129)