### PR TITLE
fix credit token listing in admin panel and sync SKL token addresses on base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ tools/*
 packages/**/dist
 
 docs/*
+.claude/launch.json

--- a/config/base/index.ts
+++ b/config/base/index.ts
@@ -363,7 +363,7 @@ export const METAPORT_CONFIG: types.mp.Config = {
           }
         },
         skl: {
-          address: '0xb49A02585E2BeB912027D8876DC1cdbE8F97C1A3',
+          address: '0xb9cAA63e09c646C1ec79aCB2158d173e64a5FEd3',
           chains: {
             'winged-bubbly-grumium': {}
           }
@@ -494,7 +494,7 @@ export const METAPORT_CONFIG: types.mp.Config = {
           }
         },
         skl: {
-          address: '0x9710566Cb041bD4cDa6CB24336bc887221d11a6e',
+          address: '0x409e1eF20aDc37dD394f42ea68D562D955acb77D',
           chains: {
             mainnet: {
               clone: true

--- a/src/components/credits/CreditsPaymentTile.tsx
+++ b/src/components/credits/CreditsPaymentTile.tsx
@@ -80,10 +80,22 @@ const CreditsPaymentTile: React.FC<CreditsPaymentTileProps> = ({
     source.displayName
     : ''
 
-  const tokenSymbol =
-    Object.keys(sourceTokens).find(
-      (symbol) => sourceTokens[symbol].address?.toLowerCase() === payment.tokenAddress.toLowerCase()
-    ) || 'unknown'
+  const configTokenSymbol = Object.keys(sourceTokens).find(
+    (symbol) => sourceTokens[symbol].address?.toLowerCase() === payment.tokenAddress.toLowerCase()
+  )
+  const [onchainTokenSymbol, setOnchainTokenSymbol] = useState<string | undefined>(undefined)
+  const tokenSymbol = configTokenSymbol ?? onchainTokenSymbol ?? 'unknown'
+
+  useEffect(() => {
+    if (configTokenSymbol || !source) return
+    let cancelled = false
+    void cs.getTokenSymbol(mpc, source.chainName, payment.tokenAddress).then((symbol) => {
+      if (!cancelled && symbol) setOnchainTokenSymbol(symbol)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [configTokenSymbol, source, payment.tokenAddress])
 
   const paymentIdPrefix = source?.displayName?.trim().charAt(0).toUpperCase() ?? ''
   const displayPaymentId = `${paymentIdPrefix ? `${paymentIdPrefix}-` : ''}${cs.getLedgerPaymentId(payment.id).toString()}`

--- a/src/components/credits/TokenAdminTile.tsx
+++ b/src/components/credits/TokenAdminTile.tsx
@@ -31,8 +31,8 @@ import {
   useWagmiSwitchNetwork,
   sendTransaction
 } from '@skalenetwork/metaport'
-import { types, units, constants, notify, contracts as coreContracts } from '@/core'
-import { prepareSignerForWrite } from '../../core/credit-station'
+import { units, helper, notify, contracts as coreContracts } from '@/core'
+import { prepareSignerForWrite, type CreditToken } from '../../core/credit-station'
 
 import MonetizationOnRoundedIcon from '@mui/icons-material/MonetizationOnRounded'
 import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded'
@@ -47,25 +47,18 @@ import { Bolt, Coins } from 'lucide-react'
 
 interface TokenAdminTileProps {
   mpc: MetaportCore
-  tokenPrices: Record<string, bigint>
-  loadTokenPrices: () => Promise<void>
+  reloadTokens: () => Promise<void>
   creditStation: Contract | undefined
   source: coreContracts.CreditStationSource
-  tokenMeta: types.mp.TokenMetadata | undefined
-  tokenData: types.mp.Token
-  symbol: string
-  setErrorMsg: (msg: string) => void
+  token: CreditToken
 }
 
 const TokenAdminTile: React.FC<TokenAdminTileProps> = ({
   mpc,
-  tokenPrices,
-  loadTokenPrices,
+  reloadTokens,
   creditStation,
   source,
-  tokenMeta,
-  tokenData,
-  symbol
+  token
 }) => {
   const [openModal, setOpenModal] = useState<boolean>(false)
   const [loading, setLoading] = useState<boolean>(false)
@@ -94,8 +87,7 @@ const TokenAdminTile: React.FC<TokenAdminTileProps> = ({
     }
     setLoading(true)
 
-    const decimals = tokenMeta?.decimals || constants.DEFAULT_ERC20_DECIMALS
-    const priceWei = units.toWei(price.toString(), decimals)
+    const priceWei = units.toWei(price.toString(), token.decimals)
 
     try {
       const signer = await prepareSignerForWrite(
@@ -108,24 +100,17 @@ const TokenAdminTile: React.FC<TokenAdminTileProps> = ({
       await sendTransaction(
         signer,
         creditStation.setPrice,
-        [tokenData.address, priceWei],
+        [token.address, priceWei],
         'creditStation:setPrice'
       )
-      notify.temporarySuccess(`Price updated for ${symbol.toUpperCase()}`)
-      await loadTokenPrices()
+      notify.temporarySuccess(`Price updated for ${token.symbol.toUpperCase()}`)
+      await reloadTokens()
     } catch (e: any) {
       notify.permanentError(e.toString())
     } finally {
       setLoading(false)
       setOpenModal(false)
     }
-  }
-
-  function getTokenPriceWei(): bigint {
-    if (tokenData.address === undefined) return 0n
-    const priceWei = tokenPrices[tokenData.address]
-    if (priceWei === undefined) return 0n
-    return priceWei
   }
 
   function getChipClass(tokenPriceWei: bigint): string {
@@ -135,17 +120,20 @@ const TokenAdminTile: React.FC<TokenAdminTileProps> = ({
     return 'chip_DELEGATED'
   }
 
-  const tokenPriceWei = getTokenPriceWei()
+  const tokenPriceWei = token.priceWei
+  const shortAddr = helper.shortAddress(token.address)
 
   return (
     <div className="mb-2.5 bg-background rounded-3xl p-4">
       <Grid container spacing={0} alignItems="center">
         <Grid size={{ xs: 12, md: 4 }}>
           <div className="flex items-center">
-            <TokenIcon tokenSymbol={symbol} size="lg" iconUrl={tokenMeta?.iconUrl} />
+            <TokenIcon tokenSymbol={token.symbol.toLowerCase()} size="lg" iconUrl={token.iconUrl} />
             <div className="ml-3.5 grow sm:grow-0">
-              <h4 className="p font-bold pOneLine uppercase text-foreground">{symbol}</h4>
-              <p className="p text-xs text-muted-foreground font-semibold">{tokenMeta?.name}</p>
+              <h4 className="p font-bold pOneLine uppercase text-foreground">{token.symbol}</h4>
+              <p className="p text-xs text-muted-foreground font-semibold">
+                {token.name ? `${token.name} · ${shortAddr}` : shortAddr}
+              </p>
             </div>
           </div>
         </Grid>
@@ -164,11 +152,7 @@ const TokenAdminTile: React.FC<TokenAdminTileProps> = ({
               size="md"
               transparent
               className="p-0! uppercase md:mr-5 md:ml-5"
-              value={units.displayBalance(
-                tokenPriceWei,
-                symbol,
-                tokenMeta?.decimals || constants.DEFAULT_ERC20_DECIMALS
-              )}
+              value={units.displayBalance(tokenPriceWei, token.symbol, token.decimals)}
               text="1 CREDIT ="
               grow
               ri={true}
@@ -201,7 +185,7 @@ const TokenAdminTile: React.FC<TokenAdminTileProps> = ({
       >
         <SkPaper gray>
           <Headline
-            text={`Set CREDIT Price - ${tokenMeta?.name}`}
+            text={`Set CREDIT Price - ${token.name ?? token.symbol.toUpperCase()}`}
             icon={<MonetizationOnRoundedIcon className="text-[17px]!" />}
             className="mb-2"
             size="small"
@@ -232,11 +216,17 @@ const TokenAdminTile: React.FC<TokenAdminTileProps> = ({
                     />
                   </div>
                   <div className="text-xs p font-bold text-foreground! mr-2.5 uppercase">
-                    {symbol}
+                    {token.symbol}
                   </div>
                 </div>
               }
-              icon={<TokenIcon tokenSymbol={symbol} size="xs" />}
+              icon={
+                <TokenIcon
+                  tokenSymbol={token.symbol.toLowerCase()}
+                  size="xs"
+                  iconUrl={token.iconUrl}
+                />
+              }
             />
           </SkPaper>
           <Button

--- a/src/components/credits/TokensAdmin.tsx
+++ b/src/components/credits/TokensAdmin.tsx
@@ -29,7 +29,7 @@ import { contracts as coreContracts, metadata, types } from '@/core'
 import TokenAdminTile from './TokenAdminTile'
 import AccordionSection from '../AccordionSection'
 import CreditStationStatusTile from './CreditStationStatusTile'
-import { getTokenPrices } from '../../core/credit-station'
+import { getCreditTokens, type CreditToken } from '../../core/credit-station'
 import { Coins, SwatchBook } from 'lucide-react'
 
 interface TokensAdminProps {
@@ -47,21 +47,18 @@ const TokensAdmin: React.FC<TokensAdminProps> = ({
   chainsMeta,
   setErrorMsg
 }) => {
-  const tokens = mpc.config.connections[source.chainName]?.erc20 ?? {}
-  const tokensMeta = mpc.config.tokens
   const network = mpc.config.skaleNetwork
   const sourceAlias =
     metadata.getAlias(network, chainsMeta, source.chainName) || source.displayName
 
-  const [tokenPrices, setTokenPrices] = useState<Record<string, bigint>>({})
+  const [creditTokens, setCreditTokens] = useState<CreditToken[] | undefined>(undefined)
 
   useEffect(() => {
-    loadTokenPrices()
+    loadTokens()
   }, [creditStation])
 
-  async function loadTokenPrices() {
-    const res = await getTokenPrices(creditStation)
-    setTokenPrices(res || {})
+  async function loadTokens() {
+    setCreditTokens(await getCreditTokens(mpc, source.chainName, creditStation))
   }
 
   return (
@@ -93,25 +90,21 @@ const TokensAdmin: React.FC<TokensAdminProps> = ({
           marg={false}
         >
           <div className="mt-2.5">
-            {Object.keys(tokens).length === 0 && (
+            {creditTokens !== undefined && creditTokens.length === 0 && (
               <div className="text-center mt-5 mb-5">
                 <p className="p text-sm text-secondary-foreground font-semibold">
-                  No tokens configured for this source
+                  No tokens available for this source
                 </p>
               </div>
             )}
-            {Object.entries(tokens).map(([symbol, tokenData]: [string, types.mp.Token]) => (
+            {(creditTokens ?? []).map((token) => (
               <TokenAdminTile
-                key={symbol}
+                key={token.address}
                 mpc={mpc}
-                tokenPrices={tokenPrices}
-                loadTokenPrices={loadTokenPrices}
+                reloadTokens={loadTokens}
                 creditStation={creditStation}
                 source={source}
-                tokenMeta={tokensMeta[symbol]}
-                tokenData={tokenData}
-                symbol={symbol}
-                setErrorMsg={(msg) => setErrorMsg(msg ?? undefined)}
+                token={token}
               />
             ))}
           </div>

--- a/src/core/credit-station.ts
+++ b/src/core/credit-station.ts
@@ -24,7 +24,7 @@
 import { Contract, type JsonRpcSigner } from 'ethers'
 import { MetaportCore, walletClientToSigner, enforceNetwork } from '@skalenetwork/metaport'
 import { skaleContracts } from '@skalenetwork/skale-contracts-ethers-v6'
-import { type types, contracts, helper } from '@/core'
+import { type types, constants, contracts, helper } from '@/core'
 
 export interface Payment {
   id: bigint
@@ -142,6 +142,57 @@ export async function getLedgerContract(
   return (await instance.getContract('Ledger')) as Contract
 }
 
+export interface TokenInfo {
+  symbol?: string
+  name?: string
+  decimals?: number
+}
+
+const ERC20_METADATA_ABI = [
+  'function symbol() view returns (string)',
+  'function name() view returns (string)',
+  'function decimals() view returns (uint8)'
+]
+const tokenInfoCache: Record<string, Promise<TokenInfo>> = {}
+
+export async function getTokenInfo(
+  mpc: MetaportCore,
+  chainName: string,
+  tokenAddress: string
+): Promise<TokenInfo> {
+  const cacheKey = `${chainName}:${tokenAddress.toLowerCase()}`
+  if (!(cacheKey in tokenInfoCache)) {
+    tokenInfoCache[cacheKey] = (async () => {
+      const token = new Contract(tokenAddress, ERC20_METADATA_ABI, mpc.provider(chainName))
+      const [symbol, name, decimals] = await Promise.allSettled([
+        token.symbol(),
+        token.name(),
+        token.decimals()
+      ])
+      if (symbol.status === 'rejected') {
+        console.error(
+          `Failed to get metadata for token ${tokenAddress} on ${chainName}:`,
+          symbol.reason
+        )
+      }
+      return {
+        symbol: symbol.status === 'fulfilled' ? symbol.value : undefined,
+        name: name.status === 'fulfilled' ? name.value : undefined,
+        decimals: decimals.status === 'fulfilled' ? Number(decimals.value) : undefined
+      }
+    })()
+  }
+  return tokenInfoCache[cacheKey]
+}
+
+export async function getTokenSymbol(
+  mpc: MetaportCore,
+  chainName: string,
+  tokenAddress: string
+): Promise<string | undefined> {
+  return (await getTokenInfo(mpc, chainName, tokenAddress)).symbol
+}
+
 export async function getTokenPrices(
   creditStation: Contract | undefined
 ): Promise<Record<string, bigint> | undefined> {
@@ -158,6 +209,80 @@ export async function getTokenPrices(
     {} as Record<string, bigint>
   )
   return priceMap
+}
+
+export interface CreditToken {
+  address: types.AddressType
+  symbol: string
+  name?: string
+  decimals: number
+  iconUrl?: string
+  priceWei: bigint
+}
+
+/**
+ * Tokens shown in the credit station admin panel. The station contract is the
+ * source of truth: every token from getSupportedTokens() is listed first, with
+ * metadata taken from the bridge config when the address matches and resolved
+ * on-chain otherwise. Bridge-config tokens the station doesn't accept yet are
+ * appended as a catalog — setPrice is also the mechanism that adds a token.
+ */
+export async function getCreditTokens(
+  mpc: MetaportCore,
+  chainName: string,
+  creditStation: Contract | undefined
+): Promise<CreditToken[]> {
+  const tokenPrices = (await getTokenPrices(creditStation)) ?? {}
+  const configTokens = mpc.config.connections[chainName]?.erc20 ?? {}
+  const tokensMeta = mpc.config.tokens
+
+  const findConfigEntry = (address: string) =>
+    Object.entries(configTokens).find(
+      ([, data]) => data.address?.toLowerCase() === address.toLowerCase()
+    )
+
+  const accepted = await Promise.all(
+    Object.entries(tokenPrices).map(async ([address, priceWei]): Promise<CreditToken> => {
+      const entry = findConfigEntry(address)
+      if (entry) {
+        const [symbol, data] = entry
+        const meta = tokensMeta[symbol]
+        return {
+          address: address as types.AddressType,
+          symbol,
+          name: meta?.name,
+          decimals: data.decimals ?? meta?.decimals ?? constants.DEFAULT_ERC20_DECIMALS,
+          iconUrl: meta?.iconUrl,
+          priceWei
+        }
+      }
+      const info = await getTokenInfo(mpc, chainName, address)
+      return {
+        address: address as types.AddressType,
+        symbol: info.symbol ?? helper.shortAddress(address as types.AddressType),
+        name: info.name,
+        decimals: info.decimals ?? constants.DEFAULT_ERC20_DECIMALS,
+        priceWei
+      }
+    })
+  )
+
+  const acceptedAddresses = new Set(Object.keys(tokenPrices).map((a) => a.toLowerCase()))
+  const catalog = Object.entries(configTokens)
+    .filter(([, data]) => data.address && !acceptedAddresses.has(data.address.toLowerCase()))
+    .map(([symbol, data]): CreditToken => {
+      const meta = tokensMeta[symbol]
+      return {
+        address: data.address as types.AddressType,
+        symbol,
+        name: meta?.name,
+        decimals: data.decimals ?? meta?.decimals ?? constants.DEFAULT_ERC20_DECIMALS,
+        iconUrl: meta?.iconUrl,
+        priceWei: 0n
+      }
+    })
+
+  return [...accepted, ...catalog]
 }
 
 export async function getTokenPricesBySource(
@@ -232,19 +357,50 @@ export async function getPaymentsByAddress(
   return await getPayments(paymentIds, creditStation, sourceId, schains)
 }
 
+async function getPaymentIfExists(
+  creditStation: Contract,
+  paymentId: bigint,
+  sourceId: string,
+  schains: types.ISChain[]
+): Promise<Payment | null> {
+  try {
+    const rawPayment = await creditStation.getPaymentInfo(paymentId)
+    return toPayment(paymentId, sourceId, rawPayment, schains)
+  } catch (error: any) {
+    // PaymentIdDoesNotExist — ids below the deployment offset
+    if (error?.code === 'CALL_EXCEPTION') return null
+    throw error
+  }
+}
+
 export async function getAllPayments(
   creditStation: Contract | undefined,
   sourceId: string,
   schains: types.ISChain[]
 ): Promise<Payment[]> {
   if (!creditStation) return []
-  const lastPaymentId = await creditStation.getLastPaymentId()
-  return getPayments(
-    Array.from({ length: Number(lastPaymentId) }, (_, i) => BigInt(i + 1)),
-    creditStation,
-    sourceId,
-    schains
-  )
+  // Payment ids are composite: source prefix in the upper bits, sequential counter
+  // in the lower bits. The counter may be seeded with an offset on redeployment,
+  // so scan down from the newest id and stop once a whole chunk is missing.
+  const lastPaymentId: bigint = await creditStation.getLastPaymentId()
+  const lastSeq = getLedgerPaymentId(lastPaymentId)
+  const idPrefix = lastPaymentId - lastSeq
+
+  const payments: Payment[] = []
+  const chunkSize = 10n
+  for (let high = lastSeq; high > 0n; high -= chunkSize) {
+    const low = high > chunkSize ? high - chunkSize : 0n
+    const chunk: bigint[] = []
+    for (let seq = high; seq > low; seq--) chunk.push(idPrefix + seq)
+    const chunkPayments = await Promise.all(
+      chunk.map((paymentId) => getPaymentIfExists(creditStation, paymentId, sourceId, schains))
+    )
+    const existing = chunkPayments.filter((p): p is Payment => p !== null)
+    payments.push(...existing)
+    if (existing.length === 0) break
+  }
+  await fillTimestamps(payments, creditStation)
+  return payments
 }
 
 export async function getPaymentsAcrossSourcesByAddress(

--- a/src/pages/CreditsAdmin.tsx
+++ b/src/pages/CreditsAdmin.tsx
@@ -126,7 +126,7 @@ const CreditsAdmin: React.FC<CreditsAdminProps> = ({
   }
 
   const sortedPayments = [...allPayments].sort((a, b) => {
-    if (b.blockNumber !== a.blockNumber) return b.blockNumber - a.blockNumber
+    if (b.timestamp !== a.timestamp) return b.timestamp - a.timestamp
     return Number(b.id - a.id)
   })
 


### PR DESCRIPTION
Fix credit token management in admin panel

The Manage Credit Tokens panel now lists tokens from the CreditStation
contract (getSupportedTokens) with metadata resolved from the bridge config
by address or on-chain, so the real SKL token (25 SKL/credit) is visible and
manageable. Syncs SKL addresses in config/base with beta (canonical
bridged SKL + its IMA clone), fixing SKL purchases. Also resolves unknown
token symbols in payment history on-chain and sorts payments by timestamp.